### PR TITLE
Close Issue#18 - No results found

### DIFF
--- a/FRONTEND/src/modules.js/navBar.js
+++ b/FRONTEND/src/modules.js/navBar.js
@@ -415,12 +415,19 @@ const initAutocomplete = (toolTopicData, addNodesFn, toolImage, databaseImage, t
         });
       }
       // The list of available tools, databases, and topics is filtered based on the input provided by the user.
-      response($.merge(subarray(matcher1), subarray(matcher2)));
+      let results = $.merge(subarray(matcher1), subarray(matcher2));
+      if (results.length === 0) {
+        results.push({ value: "No results found", labelnode: ["No results found"] });
+      }
+      response(results);
     },
     // The minimum length of the input required to trigger the autocomplete input field.
     minLength: 1,
     // The function to call when the user selects an item from the list.
     select: (event, ui) => {
+      if (ui.item.value === "No results found") {
+        return false;
+      }
       let name = ui.item.value;
       let idNode = ui.item.idNodes;
       let labelNode = ui.item.labelnode;
@@ -442,6 +449,10 @@ const initAutocomplete = (toolTopicData, addNodesFn, toolImage, databaseImage, t
       $(".ui-autocomplete").addClass("ui-autocomplete-zindex-1000");
     },
   }).autocomplete("instance")._renderItem = (ul, item) => {
+    if (item.labelnode[0] === "No results found") {
+      return $('<li>').append(`<div class="boxAutocomplete noResults">No results found</div>`).appendTo(ul);
+    }
+
     if (item.labelnode[0] === "Tool") {
       // Create a list item for the autocomplete list.
       return $(`<li>

--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -294,6 +294,10 @@ display:none
     margin-left: 3px;
 }
 
+.noResults{
+    padding: 5px;
+}
+
 .typeSoft{
     font-size: small;
     font-weight: bold;


### PR DESCRIPTION
# Description
In this PR we added a message on the autocomplete menu that informs the user when no tool/topics are being found with the provided name.
## Files changed
- `modules.js/navbar.js` -> changed the function initAutocmplete() to return a "No results found" message when the coincidences are 0.
- `styles/style.css` -> add a class to display the message with a little bit of padding
## Issues
Close #18 