### PR TITLE
Add new functionality to reset button -> Redirect to Home Page

### DIFF
--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -343,6 +343,7 @@ try {
   $("#reset").on("click", () => {
     removeAllTopicsMenu();
     reset();
+    $("#inital-screen").removeClass("hidden");
   });
 
   // Attach a click event handler to the element with the ID "stabilize".


### PR DESCRIPTION
## Description
This PR focuses on adding a new functionality to the reset button. Now, in addition to resetting the graph and the added tools, the application redirects the user to the home page.

## Changes Implemented
### `main.js`
- Modified the runtime of the application in order to show the element with id "inital-screen" when reset button is clicked.

## Issues
Closes #73 