### PR TITLE
Solved Issue#69 Hide unused elements Sidebar

### DIFF
--- a/FRONTEND/src/modules.js/navBar.js
+++ b/FRONTEND/src/modules.js/navBar.js
@@ -525,6 +525,12 @@ const removeLegend = () => {
  */
 const addLegend = () => {
   showLegend();
+  let toolsTopicsDiv = $("#topics-tools-list");
+  if ($('#tools-toggle-visibility.hidden, #topics-toggle-visibility.hidden', toolsTopicsDiv).length === $('#tools-toggle-visibility, #topics-toggle-visibility', toolsTopicsDiv).length) {
+    $("#legend").addClass("hidden");
+  } else {
+    $("#legend").removeClass("hidden");
+  }
   let optionRadio = $('input[name="cluster_mode"]:checked');
   const list = $("#legend div")[0];
   list.innerHTML = ""; // Clear any previous content in the legend


### PR DESCRIPTION
# Description
In this PR we modified the function that manages the legend to hide the legend when no tools or topics are displayed. Because when you putted normal mode without elements searched, the function displayed the legend and then will not hide the legend title but the content remained.
## Files changed:
- `modules.js/navBar.js` --> Modified the function addLegend to make a propper display of the legend
## Issues:
Closes #69 