### PR TITLE
Adds functionality to enable or disable the buttons and create a new reset page

### DIFF
--- a/FRONTEND/src/index.html
+++ b/FRONTEND/src/index.html
@@ -90,7 +90,30 @@
         <div id="main">
             <button id="openbtn" aria-label="Close/Open Menu"></button>
             <div id="liveAlertPlaceholder"></div>
-            <div id="VisNetwork"></div>
+            <div id="VisNetwork" class="hidden"></div>
+            
+            <div id="resetPage" class="hidden container w-75 p-5">
+                <div class="text-center">
+                    <img src="images/logo_InSoLiTo.png" alt="App Logo" class="img-fluid" width="300">
+                </div>
+    
+                <div class="my-3 p-3 bg-light rounded text-start shadow-sm hover-shadow">
+                    <strong class="text-primary">Your settings have been reset!</strong>
+                    <p>The filters and search criteria have been cleared. You can now start fresh.</p>
+                </div>
+                <div class="my-3 p-3 bg-light rounded text-start shadow-sm hover-shadow">
+                    <strong class="text-primary">What to do next?:</strong>
+                    <ul>
+                        <li><strong>Step 1:</strong> Enter the tool name in the search bar to find relevant data.</li>
+                        <li><strong>Step 2:</strong> Adjust the filters using the available sliders to refine your search.</li>
+                        <li><strong>Step 3:</strong> The graph will update automatically based on your selections.</li>
+                    </ul>
+                </div>
+                <div class="mt-3 p-3 bg-light rounded text-start shadow-sm hover-shadow">
+                    <strong class="text-primary">Tip:</strong> Click over the graph nodes to see additional details and gain insights.
+                </div>
+            </div>
+                    
             <div id="visualization">
                 <div id="context-menu"></div>
                 <div id="initial-screen">

--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -303,11 +303,23 @@ function initializeTooltips() {
 
 
 
+// ------------------------------ Function-11 ------------------------------
+/**
+ * Toggles the state of the buttons with the IDs "reset" and "stabilize"
+ * depending on whether the element with the ID "VisNetwork" has the class
+ * "hidden" or not.
+ *
+ * If the element with the ID "VisNetwork" has the class "hidden", the
+ * buttons are disabled, meaning they cannot be clicked. If the element
+ * does not have the class "hidden", the buttons are enabled.
+ */
 const toggleButtons = () => {
   if ($("#VisNetwork").hasClass("hidden")) {
+    // Disable the buttons
     $("#reset").prop("disabled", true);
     $("#stabilize").prop("disabled", true);
   } else {
+    // Enable the buttons
     $("#reset").prop("disabled", false);
     $("#stabilize").prop("disabled", false);
   }

--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -51,6 +51,9 @@ const alertPlaceholder = $('#liveAlertPlaceholder');
 // Select all elements with the data-bs-toggle attribute set to "tooltip"
 const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
 
+const observer = new MutationObserver(() => toggleButtons());
+observer.observe($("#VisNetwork")[0], { attributes: true, attributeFilter: ["class"] });
+
 
 
 // ------------------------------------------------------------ FUNCTIONS ------------------------------------------------------------ //
@@ -300,6 +303,18 @@ function initializeTooltips() {
 
 
 
+const toggleButtons = () => {
+  if ($("#VisNetwork").hasClass("hidden")) {
+    $("#reset").prop("disabled", true);
+    $("#stabilize").prop("disabled", true);
+  } else {
+    $("#reset").prop("disabled", false);
+    $("#stabilize").prop("disabled", false);
+  }
+}
+
+
+
 // ------------------------------------------------------------ RUNTIME ------------------------------------------------------------ //
 
 // Attach a click event handler to the element with the ID "openbtn".
@@ -322,6 +337,7 @@ try {
     hideToolsAdded();
     hideLegend();
     initializeTooltips();
+    toggleButtons();
   });
 
   // Draw the bar charts for YearBarchart and OccurBarchart.
@@ -364,9 +380,12 @@ try {
   // Attach a click event handler to the element with the ID "reset".
   // Executes when the reset button is clicked.
   $("#reset").on("click", () => {
+    if ($("#reset").prop("disabled")) return;
     removeAllTopicsMenu();
     reset();
-    $("#initial-screen").removeClass("hidden");
+    $("#initial-screen").addClass("hidden");
+    $("#VisNetwork").addClass("hidden");
+    $("#resetPage").removeClass("hidden");
   });
 
   // Attach a click event handler to the element with the ID "stabilize".

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -827,6 +827,8 @@ const addNodesGraph = async (nameNode, idNode, nodeType) => {
   let addedNodes = nodesAfter.filter((id) => !nodesBeforeQuery.includes(id));
 
   // Show the loading screen
+  $("#reset").prop("disabled", true);
+  $("#stabilize").prop("disabled", true);
   $("#initial-screen").addClass("hidden");
   const LoadingImg = $("#loadingSpinner");
   LoadingImg.attr('src', LoadingIcon);
@@ -841,6 +843,13 @@ const addNodesGraph = async (nameNode, idNode, nodeType) => {
   loadingText.addClass("loading");
   const VisNetwork = $("#VisNetwork");
   VisNetwork.addClass("hidden");
+  const resetPage = $("#resetPage");
+  resetPage.addClass("hidden");
+  setTimeout(() => {
+    list.addClass("hidden");
+    $("#reset").prop("disabled", false);
+    $("#stabilize").prop("disabled", false);
+  }, 15000);
   
   await new Promise((r) => setTimeout(r, 15000));
   

--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -612,3 +612,13 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
 #topics-tools-list {
     max-width: 85%;
 }
+
+.shadow-sm {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.hover-shadow:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transform: scale(1.02);
+    transition: all 0.3s ease;
+}


### PR DESCRIPTION
## Description
This PR focuses on enable the buttons only when handling the network.
This PR also creates a new page to redirect to when the reset button is clicked.

## Changes implemented:

### `index.html`
- Add the reset page with html and bootstrap (at first hidden).

### `main.js`
- Add functionality to redirect to reset page when the reset button is clicked. 
- Add functionality to manage enable and disable the buttons depending on the page showed.

### `modules.js/graph.js`
- Add functionality to show or hide reset page.
- Add functionality to disable buttons while searching data.

### `styles/style.css`
- Add styles to give animation to the reset page elements.

## Issues:
Closes #89 