### PR TITLE
Unify style of all buttons of the main page

### DIFF
--- a/FRONTEND/src/images/xmark-solid-white.svg
+++ b/FRONTEND/src/images/xmark-solid-white.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<svg width="320" height="512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+ <!--! Font Awesome Pro 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+
+ <g class="layer">
+  <title>Layer 1</title>
+  <path d="m310.6,361.4c12.5,12.5 12.5,32.75 0,45.25c-6.2,6.25 -14.4,9.35 -22.6,9.35s-16.38,-3.12 -22.62,-9.37l-105.38,-105.33l-105.37,105.3c-6.25,6.3 -14.44,9.4 -22.63,9.4s-16.37,-3.1 -22.62,-9.4c-12.51,-12.5 -12.51,-32.75 0,-45.25l105.4,-105.4l-105.4,-105.35c-12.51,-12.5 -12.51,-32.75 0,-45.25s32.75,-12.5 45.25,0l105.37,105.45l105.4,-105.4c12.5,-12.5 32.75,-12.5 45.25,0s12.5,32.75 0,45.25l-105.4,105.4l105.35,105.35z" fill="#ffffff" id="svg_1"/>
+ </g>
+</svg>

--- a/FRONTEND/src/index.html
+++ b/FRONTEND/src/index.html
@@ -110,7 +110,7 @@
                     </div>
                     <div class="firstStepsContainer">
                         <!-- Button trigger modal -->
-                        <button type="button" class="btn btn-secondary px-4 py-2" data-bs-toggle="modal" data-bs-target="#exampleModal">
+                        <button type="button" class="buttons btn btn-secondary px-4 py-2" data-bs-toggle="modal" data-bs-target="#exampleModal">
                             First Steps
                         </button>
                     </div>
@@ -185,7 +185,7 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+                        <button type="button" class="buttons btn btn-primary" data-bs-dismiss="modal">Close</button>
                         <!-- <button type="button" class="btn btn-primary">Save changes</button> -->
                     </div>
                 </div>

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -16,7 +16,7 @@ import ToolImage from "../images/tool_centered_sm.png";
 import PaperImage from "../images/paper_centered_sm.png";
 import DatabaseImage from "../images/database_centered_sm.png";
 import LoadingIcon from "../images/spinner-solid.svg";
-import CloseButton from "../images/xmark-solid.svg";
+import CloseButton from "../images/xmark-solid-white.svg";
 
 // Modules
 import { addLegend, removeLegend, removeAllToolsMenu, removeAllTopicsMenu } from "./navBar";

--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -352,6 +352,10 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
 
 .buttons:hover {
     font-weight: bold;
+    transform: scale(1.05) translateY(-2px);
+    box-shadow: 0 0.75rem 1.25rem rgba(0, 0, 0, 0.2);
+    transition: transform 0.5s cubic-bezier(0.19, 1, 0.22, 1),
+                box-shadow 0.5s ease;
 }
 
 #MenuImage {


### PR DESCRIPTION
## Description
This PR focuses on apply the same hover style to all button of the main page (font weight bold). Not applied to tool/topic or alert buttons.
This PR also add a new close icon image (svg format) in white color.

## Changes implemented:
### `images/xmark-solid-white.svg`
- Modify the original close icon (black color) to add a new version of the same icon (white color).

### `index.html`
- Add class "buttons" to all buttons in the main page to unify the styles.

### `modules.js/graph.js`
- Change the import of the close button from xmark-solid.svg to xmark-solid-white.svg.

### `styles/style.css`
- Change class "buttons" in hover state to apply a transition

## Issues:
Closes #95 