### PR TITLE
Close Issue#99 Fix tools topics div visibility

### DIFF
--- a/FRONTEND/src/index.html
+++ b/FRONTEND/src/index.html
@@ -16,7 +16,7 @@
             <button id="reset" class="buttons btn btn-primary d-block mb-2 w-100 shadow">Reset</button>
             <button id="stabilize" class="buttons btn btn-primary d-block mb-3 w-100 shadow">Stabilize</button>
         </div>
-        <div id="topics-tools-list" class="col-12 mb-3">
+        <div id="topics-tools-list" class="col-12 mb-3 hidden">
             <div id="topics-toggle-visibility">
                 <p class="nav-title fw-bold">Topics Added</p>
                 <div id="topics-list">

--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -28,7 +28,7 @@ import logoInSoLiTo from "./images/logo_InSoLiTo.png";
 
 // Modules
 import { actionSidebar, Barchart, sliderRangeFunction, addLegend, initAutocomplete, removeAllTopicsMenu, removeAllToolsMenu, logslider } from "./modules.js/navBar";
-import { Vis, drawVis, updateNodes, clusterMode, addNodes, reset } from "./modules.js/graph";
+import { Vis, drawVis, updateNodes, clusterMode, addNodes, resetVisualization } from "./modules.js/graph";
 
 
 
@@ -120,7 +120,7 @@ const appendAlert = (message, type) => {
     .text('Go Home')
     .on('click', () => {
       removeAllTopicsMenu();
-      reset();
+      resetVisualization();
       if ($("#initial-screen").hasClass("hidden")) {
         $("#initial-screen").removeClass("hidden");
       }
@@ -348,7 +348,7 @@ try {
   $("#reset").on("click", () => {
     if ($("#reset").prop("disabled")) return;
     removeAllTopicsMenu();
-    reset();
+    resetVisualization();
     $("#initial-screen").addClass("hidden");
     $("#VisNetwork").addClass("hidden");
     $("#resetPage").removeClass("hidden");
@@ -378,7 +378,7 @@ try {
   $("#logo-sidebar").on("click", () => {
     removeAllTopicsMenu();
     removeAllToolsMenu();
-    reset();
+    resetVisualization();
     $("#initial-screen").removeClass("hidden");
     $("#liveAlertPlaceholder").empty();
     $("#tooltopic_autocomplete").val("");

--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -28,7 +28,7 @@ import logoInSoLiTo from "./images/logo_InSoLiTo.png";
 
 // Modules
 import { actionSidebar, Barchart, sliderRangeFunction, addLegend, initAutocomplete, removeAllTopicsMenu, removeAllToolsMenu, logslider } from "./modules.js/navBar";
-import { Vis, drawVis, updateNodes, clusterMode, addNodes, resetVisualization } from "./modules.js/graph";
+import { Vis, drawVis, updateNodes, clusterMode, addNodes, reset } from "./modules.js/graph";
 
 
 
@@ -120,7 +120,7 @@ const appendAlert = (message, type) => {
     .text('Go Home')
     .on('click', () => {
       removeAllTopicsMenu();
-      resetVisualization();
+      reset();
       if ($("#initial-screen").hasClass("hidden")) {
         $("#initial-screen").removeClass("hidden");
       }
@@ -348,7 +348,7 @@ try {
   $("#reset").on("click", () => {
     if ($("#reset").prop("disabled")) return;
     removeAllTopicsMenu();
-    resetVisualization();
+    reset();
     $("#initial-screen").addClass("hidden");
     $("#VisNetwork").addClass("hidden");
     $("#resetPage").removeClass("hidden");
@@ -378,7 +378,7 @@ try {
   $("#logo-sidebar").on("click", () => {
     removeAllTopicsMenu();
     removeAllToolsMenu();
-    resetVisualization();
+    reset();
     $("#initial-screen").removeClass("hidden");
     $("#liveAlertPlaceholder").empty();
     $("#tooltopic_autocomplete").val("");

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -154,7 +154,7 @@ const updateNodes = () => {
     return;
   }
   // Reset the graph.
-  reset();
+  resetVisualization();
   // Iterate over the dictionary and add the nodes to the graph.
   Object.entries(nameNodeDict).forEach(([nameNode, [nodeInformation, typeNode]]) => {
     addNodes(nameNode, nodeInformation, typeNode);
@@ -839,7 +839,7 @@ const centerNode = (name, idNode) => {
   if (!name || !idNode) {
     console.error("name or idNode is null or empty");
   }
-  reset();
+  resetVisualization();
   removeAllTopicsMenu();
   addNodes(name, idNode, "Tool");
 }
@@ -939,7 +939,8 @@ const addTopicLabelMenu = (NameTopic, addedNodeIds) => {
       hideTopicsAdded();
       if ($(".ToolButton").length === 0) {
         removeAllTopicsMenu();
-        reset();
+        resetVisualization
+    ();
         $("#initial-screen").addClass("hidden");
         $("#VisNetwork").addClass("hidden");
         $("#resetPage").removeClass("hidden");
@@ -1037,7 +1038,8 @@ const addToolLabelMenu = (NameTopic, idNode) => {
       hideToolsAdded();
       if ($(".TopicButton").length === 0) {
         removeAllTopicsMenu();
-        reset();
+        resetVisualization
+    ();
         $("#initial-screen").addClass("hidden");
         $("#VisNetwork").addClass("hidden");
         $("#resetPage").removeClass("hidden");
@@ -1224,7 +1226,7 @@ const waitAddTool = () => {
  * Resets the graph visualization by destroying and recreating it from scratch.
  * This function is useful for resetting the graph after modifying the UI elements.
  */
-const reset = () => {
+const resetVisualization = () => {
   if (!Vis) {
     console.error("Vis is null or undefined.");
   }
@@ -1244,4 +1246,4 @@ const reset = () => {
 
 // ------------------------------------------------------------ EXPORTS ------------------------------------------------------------ //
 
-export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, reset };
+export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, resetVisualization };

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -154,7 +154,7 @@ const updateNodes = () => {
     return;
   }
   // Reset the graph.
-  resetVisualization();
+  reset();
   // Iterate over the dictionary and add the nodes to the graph.
   Object.entries(nameNodeDict).forEach(([nameNode, [nodeInformation, typeNode]]) => {
     addNodes(nameNode, nodeInformation, typeNode);
@@ -839,7 +839,7 @@ const centerNode = (name, idNode) => {
   if (!name || !idNode) {
     console.error("name or idNode is null or empty");
   }
-  resetVisualization();
+  reset();
   removeAllTopicsMenu();
   addNodes(name, idNode, "Tool");
 }
@@ -939,8 +939,7 @@ const addTopicLabelMenu = (NameTopic, addedNodeIds) => {
       hideTopicsAdded();
       if ($(".ToolButton").length === 0) {
         removeAllTopicsMenu();
-        resetVisualization
-    ();
+        reset();
         $("#initial-screen").addClass("hidden");
         $("#VisNetwork").addClass("hidden");
         $("#resetPage").removeClass("hidden");
@@ -1038,8 +1037,7 @@ const addToolLabelMenu = (NameTopic, idNode) => {
       hideToolsAdded();
       if ($(".TopicButton").length === 0) {
         removeAllTopicsMenu();
-        resetVisualization
-    ();
+        reset();
         $("#initial-screen").addClass("hidden");
         $("#VisNetwork").addClass("hidden");
         $("#resetPage").removeClass("hidden");
@@ -1226,7 +1224,7 @@ const waitAddTool = () => {
  * Resets the graph visualization by destroying and recreating it from scratch.
  * This function is useful for resetting the graph after modifying the UI elements.
  */
-const resetVisualization = () => {
+const reset = () => {
   if (!Vis) {
     console.error("Vis is null or undefined.");
   }
@@ -1246,4 +1244,4 @@ const resetVisualization = () => {
 
 // ------------------------------------------------------------ EXPORTS ------------------------------------------------------------ //
 
-export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, resetVisualization };
+export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, reset };

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -972,7 +972,7 @@ const addTopicLabelMenu = (NameTopic, addedNodeIds) => {
   // If not found, create and append the new topic button.
   if (!found) {
     let buttonTopic = $("<button>");
-    buttonTopic.addClass("btn btn-primary w-100 my-2 pe-4 TopicButton");
+    buttonTopic.addClass("btn btn-primary w-100 my-1 pe-4 TopicButton");
     buttonTopic.html(`<img class="close-icon pt-1 me-3" src="${CloseButton}"/><div class="name-topic">${NameTopic}</div>`);
     // Store the comma-separated node IDs as the button’s value.
     buttonTopic.val(addedNodeIds.join(","));


### PR DESCRIPTION
# Description
In this PR we fixed the logic that adds and removes the class `hidden` of the div that contains the divs for the tools and the topics.
## Files changed:
- `index.html` --> Added the class `hidden` to the div `#topics-tools-list` to ensure that the div is hidden when we load the page for the first time
- `modules.js/graph.js` --> Added the logic to manage the class `hidden` of the div.
## Issues:
Closes #99 