### PR TITLE
Add functionality to manage reset button and removing all tools from sidebar

### DIFF
--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -27,7 +27,7 @@ import TopicImage from "./images/topic_centered_sm.png";
 import logoInSoLiTo from "./images/logo_InSoLiTo.png";
 
 // Modules
-import { actionSidebar, Barchart, sliderRangeFunction, addLegend, initAutocomplete, removeAllTopicsMenu, removeAllToolsMenu } from "./modules.js/navBar";
+import { actionSidebar, Barchart, sliderRangeFunction, addLegend, initAutocomplete, removeAllTopicsMenu, removeAllToolsMenu, logslider } from "./modules.js/navBar";
 import { Vis, drawVis, updateNodes, clusterMode, addNodes, reset } from "./modules.js/graph";
 
 
@@ -352,6 +352,21 @@ try {
     $("#initial-screen").addClass("hidden");
     $("#VisNetwork").addClass("hidden");
     $("#resetPage").removeClass("hidden");
+    const sidebar = $("#mySidebar");
+    sidebar.find('input[type="text"]').val('');
+    sidebar.find('input[type="checkbox"]').prop('checked', false);
+    sidebar.find('input[type="radio"]').each(function () {
+      this.checked = this.defaultChecked;
+    });
+    const yearKeys = Object.keys(YearData);
+    const minYear = parseInt(yearKeys[0]);
+    const maxYear = parseInt(yearKeys[yearKeys.length - 1]);
+    $("#year-slider-range").slider("values", [minYear, maxYear]);
+    $("#yearAmount").val(minYear + " - " + maxYear);
+    $("input[name=typeOfEdges]:checked").trigger("change");
+    $("#occur-slider-range").slider("values", [1, 100]);
+    const minOccur = logslider(1);
+    $("#occurAmount").val(minOccur);
   });
 
   // Attach a click event handler to the element with the ID "stabilize".

--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -352,21 +352,19 @@ try {
     $("#initial-screen").addClass("hidden");
     $("#VisNetwork").addClass("hidden");
     $("#resetPage").removeClass("hidden");
-    const sidebar = $("#mySidebar");
-    sidebar.find('input[type="text"]').val('');
-    sidebar.find('input[type="checkbox"]').prop('checked', false);
-    sidebar.find('input[type="radio"]').each(function () {
-      this.checked = this.defaultChecked;
-    });
+    $("#tooltopic_autocomplete").val("");
+    $("#displayArticles").prop("checked", false);
+    $("#allYearsEdges").prop("checked", true);
+    $("input[name=typeOfEdges]:checked").trigger("change");
     const yearKeys = Object.keys(YearData);
     const minYear = parseInt(yearKeys[0]);
     const maxYear = parseInt(yearKeys[yearKeys.length - 1]);
     $("#year-slider-range").slider("values", [minYear, maxYear]);
     $("#yearAmount").val(minYear + " - " + maxYear);
-    $("input[name=typeOfEdges]:checked").trigger("change");
     $("#occur-slider-range").slider("values", [1, 100]);
     const minOccur = logslider(1);
     $("#occurAmount").val(minOccur);
+    $("#cluster").prop("checked", true);
   });
 
   // Attach a click event handler to the element with the ID "stabilize".

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -938,9 +938,8 @@ const addTopicLabelMenu = (NameTopic, addedNodeIds) => {
         if (!$("#topics-tools-list").hasClass("hidden")) {
           $("#topics-tools-list").addClass("hidden");  
         }
-        if ($("#initial-screen").hasClass("hidden")) {
-          $("#initial-screen").removeClass("hidden");
-        }
+        $("#VisNetwork").addClass("hidden");
+        $("#resetPage").removeClass("hidden");
         $("#reset").prop("disabled", true);
         $("#stabilize").prop("disabled", true);
       }
@@ -1045,9 +1044,8 @@ const addToolLabelMenu = (NameTopic, idNode) => {
       if (!$("#topics-tools-list").hasClass("hidden")) {
         $("#topics-tools-list").addClass("hidden");  
       }
-      if ($("#initial-screen").hasClass("hidden")) {
-        $("#initial-screen").removeClass("hidden");
-      }
+      $("#VisNetwork").addClass("hidden");
+      $("#resetPage").removeClass("hidden");
       $("#reset").prop("disabled", true);
       $("#stabilize").prop("disabled", true);
     }

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -929,25 +929,15 @@ const addTopicLabelMenu = (NameTopic, addedNodeIds) => {
     addLegend();
     if ($(".TopicButton").length === 0) {
       hideTopicsAdded();
-      if($(".TopicButton").length === 0 && $(".ToolButton").length === 0) {
-        hideTopicsAdded();
-        hideToolsAdded();
-        if (!$("#legend").hasClass("hidden")) {
-          $("#legend").addClass("hidden");  
-        }
-        if (!$("#topics-tools-list").hasClass("hidden")) {
-          $("#topics-tools-list").addClass("hidden");  
-        }
+      if ($(".ToolButton").length === 0) {
+        removeAllTopicsMenu();
+        reset();
+        $("#initial-screen").addClass("hidden");
         $("#VisNetwork").addClass("hidden");
         $("#resetPage").removeClass("hidden");
-        $("#reset").prop("disabled", true);
-        $("#stabilize").prop("disabled", true);
       }
     }
   });
-  if ($(".TopicButton").length === 0) {
-    hideTopicsAdded();
-  }
 }
 
 
@@ -1034,20 +1024,13 @@ const addToolLabelMenu = (NameTopic, idNode) => {
     addLegend();
     if ($(".ToolButton").length === 0) {
       hideToolsAdded();
-    }
-    if($(".TopicButton").length === 0 && $(".ToolButton").length === 0) {
-      hideTopicsAdded();
-      hideToolsAdded();
-      if (!$("#legend").hasClass("hidden")) {
-        $("#legend").addClass("hidden");  
+      if ($(".TopicButton").length === 0) {
+        removeAllTopicsMenu();
+        reset();
+        $("#initial-screen").addClass("hidden");
+        $("#VisNetwork").addClass("hidden");
+        $("#resetPage").removeClass("hidden");
       }
-      if (!$("#topics-tools-list").hasClass("hidden")) {
-        $("#topics-tools-list").addClass("hidden");  
-      }
-      $("#VisNetwork").addClass("hidden");
-      $("#resetPage").removeClass("hidden");
-      $("#reset").prop("disabled", true);
-      $("#stabilize").prop("disabled", true);
     }
   });
 }
@@ -1231,19 +1214,19 @@ const waitAddTool = () => {
  * This function is useful for resetting the graph after modifying the UI elements.
  */
 const reset = () => {
-    if (!Vis) {
-      console.error("Vis is null or undefined.");
-    }
-    // Destroy the current graph visualization
-    Vis.destroy();
-    // Recreate the graph visualization from scratch
-    drawVis();
-    // Remove all nodes from the graph
-    removeAllToolsMenu();
-    removeLegend();
-    hideTopicsAdded();
-    hideToolsAdded();
-    hideLegend();
+  if (!Vis) {
+    console.error("Vis is null or undefined.");
+  }
+  // Destroy the current graph visualization
+  Vis.destroy();
+  // Recreate the graph visualization from scratch
+  drawVis();
+  // Remove all nodes from the graph
+  removeAllToolsMenu();
+  removeLegend();
+  hideTopicsAdded();
+  hideToolsAdded();
+  hideLegend();
 }
 
 

--- a/FRONTEND/src/modules.js/navBar.js
+++ b/FRONTEND/src/modules.js/navBar.js
@@ -579,4 +579,4 @@ const removeAllTopicsMenu = () => {
 
 // ------------------------------------------------------------ EXPORTS ------------------------------------------------------------ //
 
-export { actionSidebar, Barchart, sliderRangeFunction, removeLegend, addLegend, initAutocomplete, removeAllToolsMenu, removeAllTopicsMenu };
+export { actionSidebar, Barchart, sliderRangeFunction, removeLegend, addLegend, initAutocomplete, removeAllToolsMenu, removeAllTopicsMenu, logslider };


### PR DESCRIPTION
## Description
This PR focuses on two main things:
- Add functionality to reset button in order to remove all search criteria.
- Add functionality when all tools are removed in order to show the reset page keeping the search criteria.

## Changes implemented:

### `main.js`
- Add the reset of search criteria when clicking in reset button.

### `modules.js/navBar.js`
- Add export of logslider function to be used in main.js file.

### `modules.js/graph.js`
- Change the functionality when all topics and tools are removed from sidebar. Instead of the event redirects to the main page, redirects to reset page.

## Issues:
Closes #102 