### PR TITLE
Fixed Issue#105 Center the spinner

### DIFF
--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -462,21 +462,20 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
     opacity: 100%;
     position: relative;
     font-size: 16pt;
+    display: flex;
+    flex-direction: column;
 }
 
 #loadingSpinner {
     width: 4em;
     animation: spin 3s infinite linear;
-    position: relative;
-    top: 50%;
-    left: 50%;
+    margin-bottom: 4vh;
 }
 
 #loadingText {
     position: relative;
-    top: 56%;
-    left: 2.5%;
     text-align: center;
+    width: 100%;
 }
 
 @keyframes spin {


### PR DESCRIPTION
# Description
In this PR we modified the display of the loading page, switching the display to `flex`, making the flex direction `column` and removing the independent positions.
## Files changed:
- `styles/style.css` --> Removed the positions `top,left,...`, added `display:flex` and `flex-direction:column`.
## Issues:
Closes #105 