### PR TITLE
Fix bug related to Loading Screen

### DIFF
--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -542,7 +542,7 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 .loading,


### PR DESCRIPTION
## Description
This issue focuses on fix a bug that not hide the loading screen when it should be hidden.

## Changes implemented
### `styles/style.css`
- Add !important to class hidden to give it priority over other display classes.

## Issues
Closes #111 