### PR TITLE
[jQuery Autocomplete] - FIX

### DIFF
--- a/FRONTEND/src/modules.js/navBar.js
+++ b/FRONTEND/src/modules.js/navBar.js
@@ -404,7 +404,7 @@ const initAutocomplete = (toolTopicData, addNodesFn, toolImage, databaseImage, t
         }
       }
       if (uniqueResults.length === 0) {
-        results.push({ value: "No results found", labelnode: ["No results found"] });
+        uniqueResults.push({ value: "No results found", labelnode: ["No results found"] });
       }
       response(uniqueResults);
     },

--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -306,9 +306,13 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
 }
 
 .ui-menu-item-wrapper.ui-state-active {
-    background-color: #cacaca;
-    color: #000;
+    background-color: #F47C21;
+    color: #fff;
     border: none;
+}
+
+.ui-menu-item-wrapper.ui-state-active img {
+    filter: brightness(0) invert(1);
 }
 
 .ui-autocomplete-zindex-1000 {


### PR DESCRIPTION
## Description
Fix problem: now the -No Results Found- message is shown when necessary. 
Hover effect color of the autocomplete has also changed.

## Changes implemented
### FRONTEND/src/modules.js/navBar.js
- Add the -No results found- to uniqueResults array instead of results array, because is the first array the one that is sent in the response.
### FRONTEND/src/styles/style.css
- Change styles of autocomplete. From gray to orange in background color. From black to white in text and icons color.

## Issues
Closes issue #119 