### PR TITLE
[Tools | Topics Divs] Fix

### DIFF
--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -535,6 +535,7 @@ const updateWithCypher = (cypherQuery) => {
       if (Vis.body && Vis.body.edgeIndices) {
         Vis.body.edgeIndices.forEach(idEdgesSet.add, idEdgesSet);
       }
+      const allQueryNodeIds = []; // Track ALL node IDs from this query (both new and existing)
       // Iterate over the results of the Cypher query
       datainput.results[0].data.forEach((element) => {
         // Ensure the element has valid data for nodes
@@ -547,6 +548,8 @@ const updateWithCypher = (cypherQuery) => {
           if (!nodeElement || !nodeElement.id) {
             throw new Error("nodeElement is null or not a valid object");
           }
+          // Add ALL node IDs from query to our tracking array (even if they already exist)
+          allQueryNodeIds.push(nodeElement.id);
           if (!idNodesSet.has(nodeElement.id)) {
             idNodesSet.add(nodeElement.id);
             if (nodeElement.labels[0] === "Publication") {
@@ -617,6 +620,8 @@ const updateWithCypher = (cypherQuery) => {
       });
       // Update the visualization with the new nodes and edges
       createVisVisualization(nodeDataArray, edgeDataArray);
+      // Return all node IDs from this query (both new and existing ones)
+      return allQueryNodeIds;
     });
 }
 
@@ -760,8 +765,9 @@ const addNodesGraph = async (nameNode, idNode, nodeType, shouldAddToSidebar = tr
 
   // Fetch data from API
   let nodesBeforeQuery = nodes.getIds();
+  let allQueryNodeIds = []; // Will contain ALL node IDs from query (both new and existing)
   try {
-    await updateWithCypher(cypherQuery);
+    allQueryNodeIds = await updateWithCypher(cypherQuery);
   } catch (error) {
     console.log(`Error in addNodesGraph: ${error.message}`);
     appendAlert('While loading a node an error has occurred. Try again with the same parameters and if the problem persists, try it in a few minutes.', 'danger')
@@ -817,6 +823,30 @@ const addNodesGraph = async (nameNode, idNode, nodeType, shouldAddToSidebar = tr
       addTopicLabelMenu(nameNode, addedNodes);
     } else {
       addToolLabelMenu(nameNode, idNode);
+    }
+  } else {
+    // If we're updating with new filters, update the existing button values with new node IDs
+    if (nodeType === "Topic") {
+      // Find the existing topic button and update its value with ALL node IDs from query
+      // Use allQueryNodeIds instead of addedNodes to include both new and existing nodes
+      let topicButtons = $(".TopicButton");
+      topicButtons.each(function() {
+        let nameTopicDiv = $(this).find('.name-topic');
+        let buttonName = nameTopicDiv.length ? nameTopicDiv.text().trim() : $(this).text().trim();
+        if (buttonName === nameNode) {
+          $(this).val(allQueryNodeIds.join(","));
+        }
+      });
+    } else {
+      // For tools, update the button value with the node ID
+      let toolButtons = $(".ToolButton");
+      toolButtons.each(function() {
+        let nameTopicDiv = $(this).find('.name-topic');
+        let buttonName = nameTopicDiv.length ? nameTopicDiv.text().trim() : $(this).text().trim();
+        if (buttonName === nameNode) {
+          $(this).val(idNode);
+        }
+      });
     }
   }
   // Execute additional logic if nodes were found

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -139,7 +139,9 @@ const updateNodes = () => {
     // Iterate over the elements and add the name of the node and its
     // information to the dictionary.
     Array.from(listLegend).forEach((element) => {
-      let nameNode = element.textContent.trim();
+      // Extract the name from the .name-topic div to avoid including button HTML
+      let nameTopicDiv = element.querySelector('.name-topic');
+      let nameNode = nameTopicDiv ? nameTopicDiv.textContent.trim() : element.textContent.trim();
       let nodeInformation = element.value || element.dataset.info;
       if (!nameNode || !nodeInformation) {
         return;
@@ -153,11 +155,12 @@ const updateNodes = () => {
   if (Object.keys(nameNodeDict).length === 0) {
     return;
   }
-  // Reset the graph.
-  resetVisualization();
+  // Clear only the graph visualization, keeping the sidebar buttons intact
+  clearGraphOnly();
   // Iterate over the dictionary and add the nodes to the graph.
+  // Pass shouldAddToSidebar=false since the buttons already exist in the sidebar
   Object.entries(nameNodeDict).forEach(([nameNode, [nodeInformation, typeNode]]) => {
-    addNodes(nameNode, nodeInformation, typeNode);
+    addNodes(nameNode, nodeInformation, typeNode, false);
   });
 }
 
@@ -625,8 +628,9 @@ const updateWithCypher = (cypherQuery) => {
  * @param {string} nameNode - The name of the node to add
  * @param {string} idNode - The ID of the node to add
  * @param {string} nodeType - The type of the node to add (Tool or Topic)
+ * @param {boolean} shouldAddToSidebar - Whether to add the node to the sidebar menu (default: true)
  */
-const addNodesGraph = async (nameNode, idNode, nodeType) => {
+const addNodesGraph = async (nameNode, idNode, nodeType, shouldAddToSidebar = true) => {
   // Check if articles should be displayed
   let displayArticles = $("#displayArticles").prop("checked");
   // Get the selected type of edges
@@ -807,11 +811,13 @@ const addNodesGraph = async (nameNode, idNode, nodeType) => {
     return;
   }
   firstSearchNoResult = false;
-  // Add the appropriate label to the menu based on node type
-  if (nodeType === "Topic") {
-    addTopicLabelMenu(nameNode, addedNodes);
-  } else {
-    addToolLabelMenu(nameNode, idNode);
+  // Add the appropriate label to the menu based on node type (only if shouldAddToSidebar is true)
+  if (shouldAddToSidebar) {
+    if (nodeType === "Topic") {
+      addTopicLabelMenu(nameNode, addedNodes);
+    } else {
+      addToolLabelMenu(nameNode, idNode);
+    }
   }
   // Execute additional logic if nodes were found
   if (nodes.length > 0) {
@@ -840,8 +846,9 @@ const addNodesGraph = async (nameNode, idNode, nodeType) => {
  * @param {string} nameNode - The name of the node to add.
  * @param {number} idNode - The ID of the node to add.
  * @param {string} nodeType - The type of node to add. Can be "Tool" or "Topic".
+ * @param {boolean} shouldAddToSidebar - Whether to add the node to the sidebar menu (default: true)
  */
-const addNodes = (nameNode, idNode, nodeType) => {
+const addNodes = (nameNode, idNode, nodeType, shouldAddToSidebar = true) => {
   if (!nameNode || !nodeType) {
     console.error("nameNode or nodeType is null or empty");
   }
@@ -850,17 +857,25 @@ const addNodes = (nameNode, idNode, nodeType) => {
     console.error("contextMenu is null or empty");
   }
   contextMenu.html("");
-  let list = $(".delete");
-  // Check if the node is already in the menu
+  // If shouldAddToSidebar is false, it means we're updating with new filters,
+  // so we should always execute the search regardless of menu state
+  if (!shouldAddToSidebar) {
+    addNodesGraph(nameNode, idNode, nodeType, shouldAddToSidebar);
+    return;
+  }
+  // Check if the node is already in the menu by looking at TopicButton and ToolButton elements
   let isInMenu = false;
-  Array.prototype.forEach.call(list, (tool) => {
-    if (tool.textContent === nameNode) {
+  let existingButtons = document.querySelectorAll('.TopicButton, .ToolButton');
+  Array.from(existingButtons).forEach((button) => {
+    let nameTopicDiv = button.querySelector('.name-topic');
+    let buttonName = nameTopicDiv ? nameTopicDiv.textContent.trim() : button.textContent.trim();
+    if (buttonName === nameNode) {
       isInMenu = true;
     }
   });
   if (!isInMenu) {
     // Add the node to the graph if it is not already in the menu
-    addNodesGraph(nameNode, idNode, nodeType);
+    addNodesGraph(nameNode, idNode, nodeType, shouldAddToSidebar);
   }
 }
 
@@ -1270,8 +1285,22 @@ const waitAddTool = () => {
 
 // ------------------------------ Function-18 ------------------------------
 /**
+ * Clears only the graph visualization without touching the sidebar buttons.
+ * This function is useful when updating filters and you want to keep the sidebar intact.
+ */
+const clearGraphOnly = () => {
+  if (!Vis) {
+    console.error("Vis is null or undefined.");
+  }
+  // Destroy the current graph visualization
+  Vis.destroy();
+  // Recreate the graph visualization from scratch
+  drawVis();
+}
+
+/**
  * Resets the graph visualization by destroying and recreating it from scratch.
- * This function is useful for resetting the graph after modifying the UI elements.
+ * This function also clears the sidebar buttons and hides UI elements.
  */
 const resetVisualization = () => {
   if (!Vis) {
@@ -1293,4 +1322,4 @@ const resetVisualization = () => {
 
 // ------------------------------------------------------------ EXPORTS ------------------------------------------------------------ //
 
-export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, resetVisualization };
+export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, resetVisualization, clearGraphOnly };


### PR DESCRIPTION
## Description
Fix topic deletion after filter changes by tracking complete node sets.
Fix sidebar buttons disappearing on filter update.

## Changes implemented
### `FRONTEND/src/modules.js/graph.js`
- In "updateNodes" function, builds a dictionary of nodes using only the clean text from .name-topic.
- Create new function called "clearGraphOnly" in order to clean only the graph, keeping the sidebar buttons.
- Add parameter to "addNodes" function to avoid duplicate nodes in the graph.
- Ensures that existing sidebar buttons are updated in allQueryNodeIds with all nodes from the filtered query.

## Issues
Closes issue #124 