### PR TITLE
Add an event listener to avoid show webpage without styles while loading

### DIFF
--- a/FRONTEND/src/index.html
+++ b/FRONTEND/src/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>InSoLiTo graph</title>
+    <style>body{visibility:hidden;}</style>
+    <script>window.addEventListener('load',()=>document.body.style.visibility='visible')</script>
 </head>
 
 


### PR DESCRIPTION
## Description
Fix the problem of showing the webpage without css.

## Changes implemented
### `FRONTEND/src/index.html`
- Add an event listener to avoid show webpage without styles while loading.

## Issues
Closes issue #126 