### PR TITLE
Make the sidebar legend collapsible

### DIFF
--- a/FRONTEND/src/index.html
+++ b/FRONTEND/src/index.html
@@ -79,16 +79,18 @@
                 </div>
             </form>
         </div>
-        <div id="legend">
-            <p class="nav-title fw-bold">Legend:</p>
-            <div id="legendBox">
-            </div>
-        </div>
-
         <!-- <a href="#" id="downloader" download="InSoLiToNetwork.png" class="buttons">Download as PNG</a> -->
-    
+
     </div>
-        
+
+    <div id="legend" class="legend-widget hidden">
+        <button class="legend-toggle" data-bs-toggle="collapse" data-bs-target="#legendBox" aria-expanded="false" aria-controls="legendBox">
+            Legend <span class="legend-chevron">&#9660;</span>
+        </button>
+        <div id="legendBox" class="collapse">
+        </div>
+    </div>
+
         <div id="main">
             <button id="openbtn" aria-label="Close/Open Menu"></button>
             <div id="liveAlertPlaceholder"></div>

--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -549,6 +549,52 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
     font-weight: bold;
 }
 
+.legend-widget {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 1000;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    min-width: 170px;
+    overflow: hidden;
+}
+
+.legend-toggle {
+    width: 100%;
+    background: #0b579f;
+    color: white;
+    border: none;
+    padding: 6px 12px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.legend-toggle:hover {
+    background: #0a4d8e;
+}
+
+.legend-chevron {
+    font-size: 0.75em;
+    display: inline-block;
+    transition: transform 0.2s ease;
+}
+
+.legend-toggle.collapsed .legend-chevron {
+    transform: rotate(-90deg);
+}
+
+#legendBox {
+    padding: 8px 10px;
+    font-size: 0.82rem;
+}
+
 .hidden {
     display: none !important;
 }


### PR DESCRIPTION
## Summary

Extract legend from sidebar into a floating collapsible widget

## Changes

**Modified files:**
- `FRONTEND/src/index.html` — moves `#legend` out of the sidebar into a standalone floating widget (`.legend-widget`) with a toggle button (`.legend-toggle`) that collapses/expands `#legendBox` via Bootstrap collapse
- `FRONTEND/src/styles/style.css` — adds styling for the floating legend widget (fixed positioning, toggle button, chevron rotation on collapse)

## Issues

Closes #131