### PR TITLE
Download graph as image or CSV

### DIFF
--- a/FRONTEND/src/index.html
+++ b/FRONTEND/src/index.html
@@ -12,6 +12,7 @@
 
 <body>
     <div id="enter-webpage" class="enter-webpage"></div>
+
     <div id="mySidebar" class="sidebar bg-light d-flex flex-column align-items-start pt-3 ps-4 pe-4">
         <img id="logo-sidebar" src="images/logo_InSoLiTo.png" alt="Logo" class="logo-sidebar ms-3 mb-2">
         <div class="col-10 pt-3">
@@ -79,15 +80,28 @@
                 </div>
             </form>
         </div>
-        <!-- <a href="#" id="downloader" download="InSoLiToNetwork.png" class="buttons">Download as PNG</a> -->
+
 
     </div>
 
-    <div id="legend" class="legend-widget hidden">
-        <button class="legend-toggle" data-bs-toggle="collapse" data-bs-target="#legendBox" aria-expanded="false" aria-controls="legendBox">
-            Legend <span class="legend-chevron">&#9660;</span>
-        </button>
-        <div id="legendBox" class="collapse">
+    <div id="widgets-container">
+        <div id="legend" class="legend-widget hidden">
+            <button class="legend-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#legendBox" aria-expanded="false" aria-controls="legendBox">
+                Legend <span class="legend-chevron">&#9660;</span>
+            </button>
+            <div id="legendBox" class="collapse">
+            </div>
+        </div>
+        <div id="export-btn-container" class="legend-widget hidden">
+            <button class="legend-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#exportBox" aria-expanded="false" aria-controls="exportBox">
+                Export <span class="legend-chevron">&#9660;</span>
+            </button>
+            <div id="exportBox" class="collapse">
+                <div class="export-options">
+                    <button id="export-png">As PNG</button>
+                    <button id="export-csv">As CSV</button>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -213,7 +227,6 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="buttons btn btn-primary" data-bs-dismiss="modal">Close</button>
-                        <!-- <button type="button" class="btn btn-primary">Save changes</button> -->
                     </div>
                 </div>
             </div>

--- a/FRONTEND/src/main.js
+++ b/FRONTEND/src/main.js
@@ -28,7 +28,7 @@ import logoInSoLiTo from "./images/logo_InSoLiTo.png";
 
 // Modules
 import { actionSidebar, Barchart, sliderRangeFunction, addLegend, initAutocomplete, removeAllTopicsMenu, removeAllToolsMenu, logslider } from "./modules.js/navBar";
-import { Vis, drawVis, updateNodes, clusterMode, addNodes, resetVisualization } from "./modules.js/graph";
+import { Vis, drawVis, updateNodes, clusterMode, addNodes, resetVisualization, exportPNG, exportCSV } from "./modules.js/graph";
 
 
 // ------------------------------------------------------------ VARIABLES ------------------------------------------------------------ //
@@ -268,13 +268,13 @@ function initializeTooltips() {
  */
 const toggleButtons = () => {
   if ($("#VisNetwork").hasClass("hidden")) {
-    // Disable the buttons
     $("#reset").prop("disabled", true);
     $("#stabilize").prop("disabled", true);
+    $("#export-btn-container").addClass("hidden");
   } else {
-    // Enable the buttons
     $("#reset").prop("disabled", false);
     $("#stabilize").prop("disabled", false);
+    $("#export-btn-container").removeClass("hidden");
   }
 }
 
@@ -304,6 +304,8 @@ try {
     initializeTooltips();
     toggleButtons();
     $("#tooltopic_autocomplete").val("");
+    $("#export-png").on("click", () => exportPNG());
+    $("#export-csv").on("click", () => exportCSV());
   });
 
   // Draw the bar charts for YearBarchart and OccurBarchart.

--- a/FRONTEND/src/modules.js/graph.js
+++ b/FRONTEND/src/modules.js/graph.js
@@ -1350,6 +1350,72 @@ const resetVisualization = () => {
 
 
 
+// ------------------------------ exportPNG ------------------------------
+/**
+ * Downloads the current graph as a PNG image with a white background.
+ */
+const exportPNG = () => {
+  const src = document.querySelector("#VisNetwork canvas");
+  if (!src) {
+    console.error("Canvas not available for export.");
+    return;
+  }
+  const tmpCanvas = document.createElement("canvas");
+  tmpCanvas.width = src.width;
+  tmpCanvas.height = src.height;
+  const ctx = tmpCanvas.getContext("2d");
+  ctx.fillStyle = "white";
+  ctx.fillRect(0, 0, tmpCanvas.width, tmpCanvas.height);
+  ctx.drawImage(src, 0, 0);
+  const link = document.createElement("a");
+  link.download = "InSoLiTo-network.png";
+  link.href = tmpCanvas.toDataURL("image/png");
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+
+
+// ------------------------------ exportCSV ------------------------------
+/**
+ * Downloads the current graph nodes and edges as two separate CSV files.
+ */
+const exportCSV = () => {
+  if (!nodes || nodes.length === 0) {
+    console.error("No graph data available for export.");
+    return;
+  }
+
+  let csv = "## NODES\n";
+  csv += "id,label,type,community,topic\n";
+  nodes.forEach((node) => {
+    const label = String(node.label || "").replace(/"/g, '""');
+    const type = String(node.Neo4jLabel || "").replace(/"/g, '""');
+    const community = node.group !== undefined ? node.group : "";
+    const topic = String((node.properties && node.properties.topiclabel) || "").replace(/"/g, '""');
+    csv += `"${node.id}","${label}","${type}","${community}","${topic}"\n`;
+  });
+
+  csv += "\n## EDGES\n";
+  csv += "from,to,co_occurrences\n";
+  edges.forEach((edge) => {
+    csv += `"${edge.from}","${edge.to}","${edge.value || ""}"\n`;
+  });
+
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.download = "InSoLiTo-graph.csv";
+  link.href = url;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+
+
 // ------------------------------------------------------------ EXPORTS ------------------------------------------------------------ //
 
-export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, resetVisualization, clearGraphOnly };
+export { Vis, drawVis, updateNodes, returnClusters, clusterMode, addNodes, resetVisualization, clearGraphOnly, exportPNG, exportCSV };

--- a/FRONTEND/src/styles/style.css
+++ b/FRONTEND/src/styles/style.css
@@ -549,15 +549,21 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
     font-weight: bold;
 }
 
-.legend-widget {
+#widgets-container {
     position: fixed;
     top: 16px;
     right: 16px;
     z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 170px;
+}
+
+.legend-widget {
     background: white;
     border-radius: 8px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-    min-width: 170px;
     overflow: hidden;
 }
 
@@ -666,6 +672,36 @@ div.vis-network div.vis-navigation div.vis-button.vis-zoomOut {
 
 #openbtn.sidebar-open {
     left: 240px;
+}
+
+#export-btn-container .legend-toggle {
+    background: #F47C21;
+}
+
+#export-btn-container .legend-toggle:hover {
+    background: #d96b12;
+}
+
+.export-options {
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.export-options button {
+    background: none;
+    border: none;
+    text-align: left;
+    padding: 3px 2px;
+    cursor: pointer;
+    width: 100%;
+    font-size: 0.82rem;
+}
+
+.export-options button:hover {
+    color: #0b579f;
+    font-weight: 600;
 }
 
 .logo-sidebar {


### PR DESCRIPTION
## Summary

Add PNG and CSV graph export functionality

## Changes

**Modified files:**
- `FRONTEND/src/index.html` — adds an "Export" floating widget (next to the Legend widget) with "As PNG" and "As CSV" buttons
- `FRONTEND/src/main.js` — wires the export buttons to `exportPNG()`/`exportCSV()`, and hides the export widget when the graph is hidden (`toggleButtons()`)
- `FRONTEND/src/modules.js/graph.js` — implements `exportPNG()` (canvas image download) and `exportCSV()` (nodes/edges data download)
- `FRONTEND/src/styles/style.css` — styling for the export widget and its buttons

## Issues

Closes #132