### PR TITLE
[REFACTOR] Graph wrapper

### DIFF
--- a/FRONTEND-nuxt/app/assets/css/main.scss
+++ b/FRONTEND-nuxt/app/assets/css/main.scss
@@ -13,6 +13,8 @@
 
     --insolito-node-primary: #396fba;
     --insolito-node-secondary: #f6934a;
+    --insolito-node-tertiary: #2fa88f;
+    --insolito-node-tertiary-dark: #1f7d69;
     --insolito-edge: #c9d9ea;
 }
 

--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -1,0 +1,113 @@
+<template>
+  <div ref="containerEl" class="graph-network" />
+</template>
+
+<script setup>
+import cytoscape from 'cytoscape'
+
+const props = defineProps({
+    // [{ id, label, type: 'Tool' | 'Database' | 'Publication' }]
+    nodes: { type: Array, default: () => [] },
+    // [{ id, source, target, weight }]
+    edges: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['node-click'])
+
+const containerEl = ref(null)
+let cy = null
+let nodeColor = {}
+let nodeBorderColor = {}
+
+// Canvas fillStyle can't resolve CSS var(), so the custom properties from
+// main.scss are read once and mirrored into plain hex values here.
+function cssVar (name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+}
+
+function toElements () {
+    const nodeEls = props.nodes.map((node) => ({
+        group: 'nodes',
+        data: { id: String(node.id), label: node.label, type: node.type }
+    }))
+    const edgeEls = props.edges.map((edge) => ({
+        group: 'edges',
+        data: {
+            id: String(edge.id),
+            source: String(edge.source),
+            target: String(edge.target),
+            weight: edge.weight || 1
+        }
+    }))
+    return [...nodeEls, ...edgeEls]
+}
+
+function runLayout () {
+    cy.layout({ name: 'cose', animate: false, fit: true }).run()
+}
+
+onMounted(() => {
+    nodeColor = {
+        Tool: cssVar('--insolito-node-primary'),
+        Database: cssVar('--insolito-node-tertiary'),
+        Publication: cssVar('--insolito-node-secondary')
+    }
+    nodeBorderColor = {
+        Tool: cssVar('--insolito-primary'),
+        Database: cssVar('--insolito-node-tertiary-dark'),
+        Publication: cssVar('--insolito-secondary-hover')
+    }
+
+    cy = cytoscape({
+        container: containerEl.value,
+        elements: toElements(),
+        style: [
+            {
+                selector: 'node',
+                style: {
+                    'background-color': (el) => nodeColor[el.data('type')] || '#999999',
+                    'border-width': 2,
+                    'border-color': (el) => nodeBorderColor[el.data('type')] || '#666666',
+                    label: 'data(label)',
+                    'font-size': 12,
+                    color: cssVar('--insolito-text'),
+                    'text-valign': 'bottom',
+                    'text-margin-y': 6
+                }
+            },
+            {
+                selector: 'edge',
+                style: {
+                    width: 'mapData(weight, 1, 10, 1, 6)',
+                    'line-color': cssVar('--insolito-edge'),
+                    'curve-style': 'bezier'
+                }
+            }
+        ],
+        layout: { name: 'cose', animate: false }
+    })
+
+    cy.on('tap', 'node', (event) => {
+        emit('node-click', event.target.data())
+    })
+})
+
+watch([() => props.nodes, () => props.edges], () => {
+    if (!cy) return
+    cy.elements().remove()
+    cy.add(toElements())
+    runLayout()
+}, { deep: true })
+
+onUnmounted(() => {
+    cy?.destroy()
+    cy = null
+})
+</script>
+
+<style scoped>
+.graph-network {
+    width: 100%;
+    height: 100%;
+}
+</style>

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -17,9 +17,10 @@
     </button>
 
     <main class="graph-main" :class="sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
-      <div class="graph-placeholder">
-        <p>The graph view is coming soon.</p>
-      </div>
+      <p class="graph-hint">
+        {{ clickedNodeLabel ? `Clicked: ${clickedNodeLabel}` : 'Click a node to test the wrapper.' }}
+      </p>
+      <GraphNetwork :nodes="mockNodes" :edges="mockEdges" class="graph-canvas" @node-click="onNodeClick" />
     </main>
   </div>
 </template>
@@ -28,6 +29,26 @@
 defineEmits(['reset'])
 
 const sidebarOpen = ref(false)
+const clickedNodeLabel = ref('')
+
+// Placeholder data until the Cypher queries are wired in (plan step 11).
+const mockNodes = [
+    { id: 1, label: 'BLAST', type: 'Tool' },
+    { id: 2, label: 'BWA', type: 'Tool' },
+    { id: 3, label: 'UniProt', type: 'Database' },
+    { id: 4, label: 'Sample publication (2021)', type: 'Publication' },
+    { id: 5, label: 'MEGA', type: 'Tool' }
+]
+const mockEdges = [
+    { id: 'e1', source: 1, target: 2, weight: 5 },
+    { id: 'e2', source: 1, target: 3, weight: 2 },
+    { id: 'e3', source: 2, target: 4, weight: 3 },
+    { id: 'e4', source: 5, target: 1, weight: 4 }
+]
+
+function onNodeClick (data) {
+    clickedNodeLabel.value = data.label
+}
 
 onMounted(() => {
     // Desktop starts with the sidebar open; narrow screens start closed (overlay pattern).
@@ -116,14 +137,22 @@ onMounted(() => {
     }
 }
 
-.graph-placeholder {
-    height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 24px;
-    text-align: center;
+.graph-hint {
+    position: fixed;
+    top: 28px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 15;
+    margin: 0;
+    padding: 6px 16px;
+    background: var(--insolito-bg);
+    border: 1px solid var(--insolito-border);
+    border-radius: 20px;
     color: var(--insolito-text-muted);
-    font-size: 1.1rem;
+    font-size: 0.9rem;
+}
+
+.graph-canvas {
+    height: 100vh;
 }
 </style>

--- a/FRONTEND-nuxt/package-lock.json
+++ b/FRONTEND-nuxt/package-lock.json
@@ -11,6 +11,7 @@
         "@pinia/nuxt": "^0.11.3",
         "bootstrap": "^5.3.3",
         "bootstrap-vue-next": "^0.45.7",
+        "cytoscape": "^3.34.0",
         "nuxt": "^4.4.8",
         "pinia": "^3.0.4",
         "vue": "^3.5.39",
@@ -5489,6 +5490,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/db0": {
       "version": "0.3.4",

--- a/FRONTEND-nuxt/package.json
+++ b/FRONTEND-nuxt/package.json
@@ -14,6 +14,7 @@
     "@pinia/nuxt": "^0.11.3",
     "bootstrap": "^5.3.3",
     "bootstrap-vue-next": "^0.45.7",
+    "cytoscape": "^3.34.0",
     "nuxt": "^4.4.8",
     "pinia": "^3.0.4",
     "vue": "^3.5.39",


### PR DESCRIPTION
## Summary

Add Cytoscape.js graph wrapper component

## Changes

**New files:**
- `FRONTEND-nuxt/app/components/graph/Network.vue` — Vue component wrapping the `cytoscape` library.

**Modified files:**
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — replaces the previous graph placeholder with `GraphNetwork` using temporary mock data.
- `FRONTEND-nuxt/app/assets/css/main.scss` — adds `--insolito-node-tertiary` and `--insolito-node-tertiary-dark` (for Database nodes); Tool and Publication node colors reuse the existing brand palette.
- `FRONTEND-nuxt/package.json` / `FRONTEND-nuxt/package-lock.json` — adds the `cytoscape` dependency.

## Issues

Closes #143