### PR TITLE
[REFACTOR] graphStore

### DIFF
--- a/FRONTEND-nuxt/app/app.vue
+++ b/FRONTEND-nuxt/app/app.vue
@@ -2,7 +2,7 @@
   <BApp>
     <NuxtRouteAnnouncer />
     <div v-if="showGraph">
-      <GraphScreen @reset="onReset" />
+      <GraphScreen />
     </div>
     <div v-else class="enter-webpage">
       <LandingHero @explore="showGraph = true" @about="showAbout = true" />
@@ -15,10 +15,6 @@
 <script setup>
 const showAbout = ref(false)
 const showGraph = ref(false)
-
-function onReset () {
-    // Placeholder until graph store/wrapper exists (plan step 4/5)
-}
 </script>
 
 <style scoped>

--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -6,9 +6,9 @@
 import cytoscape from 'cytoscape'
 
 const props = defineProps({
-    // [{ id, label, type: 'Tool' | 'Database' | 'Publication' }]
+    // [{ id, label, type: 'Tool' | 'Database' | 'Publication', properties }]
     nodes: { type: Array, default: () => [] },
-    // [{ id, source, target, weight }]
+    // [{ id, source, target, weight, properties }]
     edges: { type: Array, default: () => [] }
 })
 
@@ -28,7 +28,7 @@ function cssVar (name) {
 function toElements () {
     const nodeEls = props.nodes.map((node) => ({
         group: 'nodes',
-        data: { id: String(node.id), label: node.label, type: node.type }
+        data: { id: String(node.id), label: node.label, type: node.type, properties: node.properties }
     }))
     const edgeEls = props.edges.map((edge) => ({
         group: 'edges',
@@ -36,7 +36,8 @@ function toElements () {
             id: String(edge.id),
             source: String(edge.source),
             target: String(edge.target),
-            weight: edge.weight || 1
+            weight: edge.weight || 1,
+            properties: edge.properties
         }
     }))
     return [...nodeEls, ...edgeEls]

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="graph-screen">
-    <GraphSidebar :open="sidebarOpen" @reset="$emit('reset')" />
+    <GraphSidebar :open="sidebarOpen" @reset="graphStore.reset()" />
 
     <div v-if="sidebarOpen" class="sidebar-backdrop" @click="sidebarOpen = false" />
 
@@ -20,34 +20,37 @@
       <p class="graph-hint">
         {{ clickedNodeLabel ? `Clicked: ${clickedNodeLabel}` : 'Click a node to test the wrapper.' }}
       </p>
-      <GraphNetwork :nodes="mockNodes" :edges="mockEdges" class="graph-canvas" @node-click="onNodeClick" />
+      <GraphNetwork :nodes="graphStore.nodes" :edges="graphStore.edges" class="graph-canvas" @node-click="onNodeClick" />
     </main>
   </div>
 </template>
 
 <script setup>
-defineEmits(['reset'])
+const graphStore = useGraphStore()
 
 const sidebarOpen = ref(false)
 const clickedNodeLabel = ref('')
 
-// Placeholder data until the Cypher queries are wired in (plan step 11).
+// Seeds the store with placeholder data until the Cypher queries are wired
+// in (plan step 11). Each node carries its full `properties` object, same
+// shape Neo4j will eventually send, so the store doesn't need a redesign
+// when new fields (pageRank, doi, etc.) start getting used in the UI.
 const mockNodes = [
-    { id: 1, label: 'BLAST', type: 'Tool' },
-    { id: 2, label: 'BWA', type: 'Tool' },
-    { id: 3, label: 'UniProt', type: 'Database' },
-    { id: 4, label: 'Sample publication (2021)', type: 'Publication' },
-    { id: 5, label: 'MEGA', type: 'Tool' }
+    { id: 1, label: 'BLAST', type: 'Tool', properties: { label: 'blast', pageRank: 0.42, toolType: ['Tool'] } },
+    { id: 2, label: 'BWA', type: 'Tool', properties: { label: 'bwa', pageRank: 0.31, toolType: ['Tool'] } },
+    { id: 3, label: 'UniProt', type: 'Database', properties: { label: 'uniprot', pageRank: 0.55, toolType: ['Database'] } },
+    { id: 4, label: 'Sample publication (2021)', type: 'Publication', properties: { title: 'Sample publication (2021)', year: 2021, doi: '10.1000/sample', pmid: '12345678' } },
+    { id: 5, label: 'MEGA', type: 'Tool', properties: { label: 'mega', pageRank: 0.18, toolType: ['Tool'] } }
 ]
 const mockEdges = [
-    { id: 'e1', source: 1, target: 2, weight: 5 },
-    { id: 'e2', source: 1, target: 3, weight: 2 },
-    { id: 'e3', source: 2, target: 4, weight: 3 },
-    { id: 'e4', source: 5, target: 1, weight: 4 }
+    { id: 'e1', source: 1, target: 2, weight: 5, properties: { times: 5, year: 2019 } },
+    { id: 'e2', source: 1, target: 3, weight: 2, properties: { times: 2, year: 2020 } },
+    { id: 'e3', source: 2, target: 4, weight: 3, properties: { times: 3, year: 2021 } },
+    { id: 'e4', source: 5, target: 1, weight: 4, properties: { times: 4, year: 2018 } }
 ]
 
 function onNodeClick (data) {
-    clickedNodeLabel.value = data.label
+    clickedNodeLabel.value = `${data.label} (pageRank: ${data.properties?.pageRank ?? 'n/a'})`
 }
 
 onMounted(() => {
@@ -55,6 +58,8 @@ onMounted(() => {
     if (!window.matchMedia('(max-width: 600px)').matches) {
         sidebarOpen.value = true
     }
+
+    graphStore.setGraph(mockNodes, mockEdges)
 })
 </script>
 

--- a/FRONTEND-nuxt/app/stores/graph.js
+++ b/FRONTEND-nuxt/app/stores/graph.js
@@ -1,0 +1,19 @@
+export const useGraphStore = defineStore('graph', () => {
+    // Each node/edge keeps the full `properties` object from Neo4j (not just
+    // the fields the UI happens to render today), so future features don't
+    // require redesigning the store.
+    const nodes = ref([])
+    const edges = ref([])
+
+    function setGraph (newNodes, newEdges) {
+        nodes.value = newNodes
+        edges.value = newEdges
+    }
+
+    function reset () {
+        nodes.value = []
+        edges.value = []
+    }
+
+    return { nodes, edges, setGraph, reset }
+})


### PR DESCRIPTION
## Summary

Add graphStore Pinia store for graph nodes/edges

## Changes

**New files:**
- `FRONTEND-nuxt/app/stores/graph.js` — `graphStore`, holding reactive nodes/edges state with `setGraph()` and `reset()` actions.

**Modified files:**
- `FRONTEND-nuxt/app/components/graph/Network.vue` — emits the full node object instead of only the node ID.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — replaces the local mock nodes/edges state with `graphStore`.
- `FRONTEND-nuxt/app/app.vue` — removes the unused `onReset`, since `Screen.vue` handles reset directly against the store.

## Issues

Closes #145