### PR TITLE
[REFACTOR] Node info menu

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -12,7 +12,7 @@ const props = defineProps({
     edges: { type: Array, default: () => [] }
 })
 
-const emit = defineEmits(['node-click'])
+const emit = defineEmits(['node-click', 'background-click'])
 
 const containerEl = ref(null)
 let cy = null
@@ -90,6 +90,12 @@ onMounted(() => {
 
     cy.on('tap', 'node', (event) => {
         emit('node-click', event.target.data())
+    })
+
+    cy.on('tap', (event) => {
+        if (event.target === cy) {
+            emit('background-click')
+        }
     })
 })
 

--- a/FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue
+++ b/FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="node-info-panel" :data-node-type="node.type">
+    <button class="node-info-close" aria-label="Close panel" @click="$emit('close')">
+      &times;
+    </button>
+
+    <template v-if="node.type === 'Publication'">
+      <p class="node-info-type">Publication</p>
+      <h3 class="node-info-title">{{ node.properties?.title || node.label }}</h3>
+      <p v-if="node.properties?.year" class="node-info-meta">{{ node.properties.year }}</p>
+      <div class="node-info-links">
+        <a
+          v-if="node.properties?.doi"
+          :href="`https://doi.org/${node.properties.doi}`"
+          target="_blank"
+          rel="noopener noreferrer"
+        >DOI</a>
+        <a
+          v-if="node.properties?.pmid"
+          :href="`https://pubmed.ncbi.nlm.nih.gov/${node.properties.pmid}/`"
+          target="_blank"
+          rel="noopener noreferrer"
+        >PubMed</a>
+      </div>
+    </template>
+
+    <template v-else>
+      <p class="node-info-type">{{ node.type }}</p>
+      <h3 class="node-info-title">{{ node.label }}</h3>
+      <div class="node-info-links">
+        <a
+          v-if="node.properties?.label"
+          :href="`https://openebench.bsc.es/tool/${node.properties.label}`"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Webpage</a>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+    // { id, label, type: 'Tool' | 'Database' | 'Publication', properties }
+    node: { type: Object, required: true }
+})
+defineEmits(['close'])
+</script>
+
+<style scoped>
+.node-info-panel {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 18;
+    width: 260px;
+    box-sizing: border-box;
+    padding: 20px;
+    background: var(--insolito-bg);
+    border-radius: 8px;
+    border-top: 4px solid var(--insolito-border);
+    box-shadow: 0 6px 24px rgba(28, 43, 58, 0.24);
+}
+
+.node-info-panel[data-node-type='Tool'] {
+    border-top-color: var(--insolito-node-primary);
+}
+
+.node-info-panel[data-node-type='Database'] {
+    border-top-color: var(--insolito-node-tertiary);
+}
+
+.node-info-panel[data-node-type='Publication'] {
+    border-top-color: var(--insolito-node-secondary);
+}
+
+@media (max-width: 600px) {
+    .node-info-panel {
+        /* Clears the toggle button (top:20px, 40px tall) instead of overlapping it */
+        top: 76px;
+        left: 16px;
+        right: 16px;
+        width: auto;
+    }
+}
+
+.node-info-close {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    border: none;
+    background: none;
+    font-size: 1.4rem;
+    line-height: 1;
+    color: var(--insolito-text-muted);
+    cursor: pointer;
+}
+
+.node-info-close:hover {
+    color: var(--insolito-text);
+}
+
+.node-info-type {
+    margin: 0 0 4px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--insolito-text-muted);
+}
+
+.node-info-title {
+    margin: 0 0 6px;
+    font-size: 1.05rem;
+    color: var(--insolito-text);
+}
+
+.node-info-meta {
+    margin: 0 0 12px;
+    font-size: 0.85rem;
+    color: var(--insolito-text-muted);
+}
+
+.node-info-links {
+    display: flex;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.node-info-links a {
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+</style>

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="graph-screen">
-    <GraphSidebar :open="sidebarOpen" @reset="graphStore.reset()" />
+    <GraphSidebar :open="sidebarOpen" @reset="onReset" />
 
     <div v-if="sidebarOpen" class="sidebar-backdrop" @click="sidebarOpen = false" />
 
@@ -17,10 +17,14 @@
     </button>
 
     <main class="graph-main" :class="sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
-      <p class="graph-hint">
-        {{ clickedNodeLabel ? `Clicked: ${clickedNodeLabel}` : 'Click a node to test the wrapper.' }}
-      </p>
-      <GraphNetwork :nodes="graphStore.nodes" :edges="graphStore.edges" class="graph-canvas" @node-click="onNodeClick" />
+      <GraphNodeInfoPanel v-if="selectedNode" :node="selectedNode" @close="selectedNode = null" />
+      <GraphNetwork
+        :nodes="graphStore.nodes"
+        :edges="graphStore.edges"
+        class="graph-canvas"
+        @node-click="selectedNode = $event"
+        @background-click="selectedNode = null"
+      />
     </main>
   </div>
 </template>
@@ -29,7 +33,12 @@
 const graphStore = useGraphStore()
 
 const sidebarOpen = ref(false)
-const clickedNodeLabel = ref('')
+const selectedNode = ref(null)
+
+function onReset () {
+    graphStore.reset()
+    selectedNode.value = null
+}
 
 // Seeds the store with placeholder data until the Cypher queries are wired
 // in (plan step 11). Each node carries its full `properties` object, same
@@ -48,10 +57,6 @@ const mockEdges = [
     { id: 'e3', source: 2, target: 4, weight: 3, properties: { times: 3, year: 2021 } },
     { id: 'e4', source: 5, target: 1, weight: 4, properties: { times: 4, year: 2018 } }
 ]
-
-function onNodeClick (data) {
-    clickedNodeLabel.value = `${data.label} (pageRank: ${data.properties?.pageRank ?? 'n/a'})`
-}
 
 onMounted(() => {
     // Desktop starts with the sidebar open; narrow screens start closed (overlay pattern).
@@ -140,21 +145,6 @@ onMounted(() => {
     .sidebar-backdrop {
         display: block;
     }
-}
-
-.graph-hint {
-    position: fixed;
-    top: 28px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 15;
-    margin: 0;
-    padding: 6px 16px;
-    background: var(--insolito-bg);
-    border: 1px solid var(--insolito-border);
-    border-radius: 20px;
-    color: var(--insolito-text-muted);
-    font-size: 0.9rem;
 }
 
 .graph-canvas {


### PR DESCRIPTION
## Summary

Add node info menu on click

## Changes

**New files:**
- `FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue` — menu shown when a node is clicked.

**Modified files:**
- `FRONTEND-nuxt/app/components/graph/Network.vue` — adds a background-click event, so the panel can be dismissed by clicking outside a node.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — `selectedNode` state controls the panel, set on `node-click` and cleared on `background-click` or the panel's close button. The sidebar's Reset button now also clears `selectedNode`.

## Issues

Closes #147