### PR TITLE
[REFACTOR] filterStore

### DIFF
--- a/FRONTEND-nuxt/app/stores/filter.js
+++ b/FRONTEND-nuxt/app/stores/filter.js
@@ -1,0 +1,20 @@
+export const useFilterStore = defineStore('filter', () => {
+    // null means "no filter" (matches the METAOCCUR_ALL query variant, no year/occurrence condition)
+    const yearMin = ref(null)
+    const yearMax = ref(null)
+    const occurrenceMin = ref(null)
+
+    function setFilters (newYearMin, newYearMax, newOccurrenceMin) {
+        yearMin.value = newYearMin
+        yearMax.value = newYearMax
+        occurrenceMin.value = newOccurrenceMin
+    }
+
+    function reset () {
+        yearMin.value = null
+        yearMax.value = null
+        occurrenceMin.value = null
+    }
+
+    return { yearMin, yearMax, occurrenceMin, setFilters, reset }
+})


### PR DESCRIPTION
## Summary

Add filterStore Pinia store for graph year/occurrence filters

## Changes

**New files:**
- `FRONTEND-nuxt/app/stores/filter.js` — `filterStore`, holding reactive `yearMin`, `yearMax`, and `occurrenceMin` state (defaulting to `null`, meaning no filter) with `setFilters()` and `reset()` actions.

## Issues

Closes #149