### PR TITLE
[REFACTOR] Sliders

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Histogram.vue
+++ b/FRONTEND-nuxt/app/components/graph/Histogram.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="histogram" aria-hidden="true">
+    <div
+      v-for="(height, i) in bars"
+      :key="i"
+      class="histogram-bar"
+      :style="{ height: height + '%' }"
+    />
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    values: { type: Array, required: true }
+})
+
+const bars = computed(() => {
+    const max = Math.max(...props.values, 0)
+    if (max === 0) return props.values.map(() => 0)
+    return props.values.map((v) => (v / max) * 100)
+})
+</script>
+
+<style scoped>
+.histogram {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 32px;
+}
+
+.histogram-bar {
+    flex: 1;
+    min-width: 1px;
+    min-height: 1px;
+    background: var(--insolito-node-primary);
+    border-radius: 1px 1px 0 0;
+}
+</style>

--- a/FRONTEND-nuxt/app/components/graph/RangeSlider.vue
+++ b/FRONTEND-nuxt/app/components/graph/RangeSlider.vue
@@ -1,0 +1,185 @@
+<template>
+  <div ref="trackRef" class="range-slider" @pointerdown="onTrackPointerDown">
+    <div class="range-slider-fill" :style="fillStyle" />
+    <button
+      v-for="(percent, i) in thumbPercents"
+      :key="i"
+      type="button"
+      class="range-slider-thumb"
+      :style="{ left: percent + '%' }"
+      role="slider"
+      aria-orientation="horizontal"
+      :aria-valuemin="min"
+      :aria-valuemax="max"
+      :aria-valuenow="values[i]"
+      tabindex="0"
+      @pointerdown.stop="startDrag(i, $event)"
+      @keydown="onKeydown(i, $event)"
+    />
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    min: { type: Number, required: true },
+    max: { type: Number, required: true },
+    modelValue: { type: [Number, Array], required: true },
+    step: { type: Number, default: 1 },
+    // Optional non-linear mapping (e.g. log scale). Both default to linear over [min, max].
+    toPercent: { type: Function, default: null },
+    fromPercent: { type: Function, default: null }
+})
+const emit = defineEmits(['update:modelValue', 'change'])
+
+const isRange = computed(() => Array.isArray(props.modelValue))
+const values = computed(() => (isRange.value ? props.modelValue : [props.modelValue]))
+
+const valueToPercent = (value) => (props.toPercent
+    ? props.toPercent(value)
+    : ((value - props.min) / (props.max - props.min)) * 100)
+
+const percentToValue = (percent) => {
+    const raw = props.fromPercent
+        ? props.fromPercent(percent)
+        : props.min + (percent / 100) * (props.max - props.min)
+    const stepped = Math.round(raw / props.step) * props.step
+    return Math.min(props.max, Math.max(props.min, stepped))
+}
+
+const thumbPercents = computed(() => values.value.map(valueToPercent))
+
+const fillStyle = computed(() => {
+    if (isRange.value) {
+        const [lo, hi] = thumbPercents.value
+        return { left: lo + '%', width: Math.max(0, hi - lo) + '%' }
+    }
+    return { left: '0%', width: thumbPercents.value[0] + '%' }
+})
+
+const trackRef = ref(null)
+
+function percentFromEvent (event) {
+    const rect = trackRef.value.getBoundingClientRect()
+    const raw = ((event.clientX - rect.left) / rect.width) * 100
+    return Math.min(100, Math.max(0, raw))
+}
+
+function clampToNeighbours (index, value) {
+    if (!isRange.value) return value
+    if (index === 0) return Math.min(value, values.value[1])
+    return Math.max(value, values.value[0])
+}
+
+function emitValues (nextValues, eventName) {
+    emit(eventName, isRange.value ? nextValues : nextValues[0])
+}
+
+function applyToIndex (index, value) {
+    const next = [...values.value]
+    next[index] = clampToNeighbours(index, value)
+    return next
+}
+
+let dragIndex = null
+
+function startDrag (index, event) {
+    dragIndex = index
+    event.target.setPointerCapture(event.pointerId)
+    window.addEventListener('pointermove', onDrag)
+    window.addEventListener('pointerup', stopDrag)
+}
+
+function onDrag (event) {
+    if (dragIndex === null) return
+    const value = percentToValue(percentFromEvent(event))
+    emitValues(applyToIndex(dragIndex, value), 'update:modelValue')
+}
+
+function stopDrag () {
+    if (dragIndex === null) return
+    dragIndex = null
+    window.removeEventListener('pointermove', onDrag)
+    window.removeEventListener('pointerup', stopDrag)
+    emitValues(values.value, 'change')
+}
+
+function onTrackPointerDown (event) {
+    const percent = percentFromEvent(event)
+    const distances = values.value.map((v) => Math.abs(valueToPercent(v) - percent))
+    const index = distances.length > 1 && distances[1] < distances[0] ? 1 : 0
+    const value = percentToValue(percent)
+    const next = applyToIndex(index, value)
+    emitValues(next, 'update:modelValue')
+    emitValues(next, 'change')
+}
+
+function onKeydown (index, event) {
+    let delta = 0
+    if (event.key === 'ArrowRight' || event.key === 'ArrowUp') delta = props.step
+    else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') delta = -props.step
+    else if (event.key === 'Home') { commitValue(index, props.min); return }
+    else if (event.key === 'End') { commitValue(index, props.max); return }
+    else return
+    event.preventDefault()
+    commitValue(index, values.value[index] + delta)
+}
+
+function commitValue (index, rawValue) {
+    const value = Math.min(props.max, Math.max(props.min, rawValue))
+    const next = applyToIndex(index, value)
+    emitValues(next, 'update:modelValue')
+    emitValues(next, 'change')
+}
+</script>
+
+<style scoped>
+.range-slider {
+    position: relative;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    touch-action: none;
+}
+
+.range-slider::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--insolito-border);
+}
+
+.range-slider-fill {
+    position: absolute;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--insolito-primary);
+}
+
+.range-slider-thumb {
+    position: absolute;
+    top: 50%;
+    width: 16px;
+    height: 16px;
+    margin-left: -8px;
+    transform: translateY(-50%);
+    border-radius: 50%;
+    background: var(--insolito-bg);
+    border: 2px solid var(--insolito-primary);
+    box-shadow: 0 1px 4px rgba(28, 43, 58, 0.25);
+    cursor: grab;
+    padding: 0;
+}
+
+.range-slider-thumb:active {
+    cursor: grabbing;
+}
+
+.range-slider-thumb:focus-visible {
+    outline: 2px solid var(--insolito-secondary);
+    outline-offset: 2px;
+}
+</style>

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -2,21 +2,87 @@
   <aside class="graph-sidebar" :class="open ? 'graph-sidebar-open' : 'graph-sidebar-closed'">
     <img src="~/assets/images/logo_InSoLiTo.png" alt="InSoLiTo Logo" class="graph-sidebar-logo">
 
-    <BButton class="graph-sidebar-reset" @click="$emit('reset')">
+    <BButton class="graph-sidebar-reset" @click="onReset">
       Reset
     </BButton>
 
+    <section class="graph-sidebar-filter">
+      <h3 class="graph-sidebar-filter-title">Publication year</h3>
+      <GraphHistogram :values="yearCounts" />
+      <GraphRangeSlider
+        v-model="yearRange"
+        :min="yearDomainMin"
+        :max="yearDomainMax"
+        @change="onYearChange"
+      />
+      <p class="graph-sidebar-filter-value">{{ yearRange[0] }} – {{ yearRange[1] }}</p>
+    </section>
+
+    <section class="graph-sidebar-filter">
+      <h3 class="graph-sidebar-filter-title">Minimum co-citations</h3>
+      <GraphHistogram :values="occurrenceDensities" />
+      <GraphRangeSlider
+        v-model="occurrenceValue"
+        :min="occurrenceDomainMin"
+        :max="occurrenceDomainMax"
+        :to-percent="occurrenceToPercent"
+        :from-percent="occurrencePercentToValue"
+        @change="onOccurrenceChange"
+      />
+      <p class="graph-sidebar-filter-value">{{ occurrenceValue }}</p>
+    </section>
+
     <p class="graph-sidebar-placeholder">
-      Search, filters and legend will appear here.
+      Search and legend will appear here.
     </p>
   </aside>
 </template>
 
 <script setup>
+import YearData from '../../../../DB/YearSliderData.json'
+import OccurData from '../../../../DB/RelationshipSliderData.json'
+
 defineProps({
     open: { type: Boolean, default: true }
 })
-defineEmits(['reset'])
+const emit = defineEmits(['reset'])
+
+const filterStore = useFilterStore()
+
+// Publication year: linear domain, taken straight from the year -> count map.
+const yearEntries = Object.entries(YearData).map(([year, count]) => [Number(year), count]).sort((a, b) => a[0] - b[0])
+const yearDomainMin = yearEntries[0][0]
+const yearDomainMax = yearEntries[yearEntries.length - 1][0]
+const yearCounts = yearEntries.map(([, count]) => count)
+const yearRange = ref([yearDomainMin, yearDomainMax])
+
+function onYearChange () {
+    filterStore.setFilters(yearRange.value[0], yearRange.value[1], occurrenceValue.value)
+}
+
+// Minimum co-citations: log-scaled domain (occurrence counts span 2..~14000,
+// most edges cluster at the low end) — same shape as the old logslider(), but
+// bidirectional so the thumb can be positioned from a stored value, not just read from one.
+const occurrenceEntries = Object.entries(OccurData).map(([times, density]) => [Number(times), density]).sort((a, b) => a[0] - b[0])
+const occurrenceDomainMin = occurrenceEntries[0][0]
+const occurrenceDomainMax = occurrenceEntries[occurrenceEntries.length - 1][0]
+const occurrenceDensities = occurrenceEntries.map(([, density]) => density)
+const occurrenceLogMin = Math.log(occurrenceDomainMin)
+const occurrenceLogMax = Math.log(occurrenceDomainMax)
+const occurrenceToPercent = (value) => ((Math.log(value) - occurrenceLogMin) / (occurrenceLogMax - occurrenceLogMin)) * 100
+const occurrencePercentToValue = (percent) => Math.round(Math.exp(occurrenceLogMin + (percent / 100) * (occurrenceLogMax - occurrenceLogMin)))
+const occurrenceValue = ref(occurrenceDomainMin)
+
+function onOccurrenceChange () {
+    filterStore.setFilters(yearRange.value[0], yearRange.value[1], occurrenceValue.value)
+}
+
+function onReset () {
+    yearRange.value = [yearDomainMin, yearDomainMax]
+    occurrenceValue.value = occurrenceDomainMin
+    filterStore.reset()
+    emit('reset')
+}
 </script>
 
 <style scoped>
@@ -67,5 +133,28 @@ defineEmits(['reset'])
     color: var(--insolito-text-muted);
     font-size: 0.9rem;
     line-height: 1.5;
+}
+
+.graph-sidebar-filter {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.graph-sidebar-filter-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--insolito-text-muted);
+    margin: 0;
+}
+
+.graph-sidebar-filter-value {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--insolito-text);
+    margin: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

Migrate year and occurrence sliders to Vue with a custom RangeSlider component

## Changes

**New files:**
- `FRONTEND-nuxt/app/components/graph/RangeSlider.vue` — generic dual-thumb/single-thumb slider built with pointer events.
- `FRONTEND-nuxt/app/components/graph/Histogram.vue` — component that renders an array of values as bars.

**Modified files:**
- `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — replaces the placeholder content with "Publication year" and "Minimum co-citations" filter sections, each combining a `Histogram` and `RangeSlider`.

## Issues

Closes #153