### PR TITLE
[REFACTOR] Search input

### DIFF
--- a/FRONTEND-nuxt/app/assets/css/main.scss
+++ b/FRONTEND-nuxt/app/assets/css/main.scss
@@ -16,6 +16,7 @@
     --insolito-node-tertiary: #2fa88f;
     --insolito-node-tertiary-dark: #1f7d69;
     --insolito-edge: #c9d9ea;
+    --insolito-danger: #c0392b;
 }
 
 html,

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -18,6 +18,9 @@
 
     <main class="graph-main" :class="uiStore.sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
       <GraphNodeInfoPanel v-if="selectedNode" :node="selectedNode" @close="selectedNode = null" />
+      <p v-if="graphStore.nodes.length === 0" class="graph-empty-state">
+        Search for a tool or topic in the sidebar to get started.
+      </p>
       <GraphNetwork
         :nodes="graphStore.nodes"
         :edges="graphStore.edges"
@@ -40,31 +43,11 @@ function onReset () {
     selectedNode.value = null
 }
 
-// Seeds the store with placeholder data until the Cypher queries are wired
-// in (plan step 11). Each node carries its full `properties` object, same
-// shape Neo4j will eventually send, so the store doesn't need a redesign
-// when new fields (pageRank, doi, etc.) start getting used in the UI.
-const mockNodes = [
-    { id: 1, label: 'BLAST', type: 'Tool', properties: { label: 'blast', pageRank: 0.42, toolType: ['Tool'] } },
-    { id: 2, label: 'BWA', type: 'Tool', properties: { label: 'bwa', pageRank: 0.31, toolType: ['Tool'] } },
-    { id: 3, label: 'UniProt', type: 'Database', properties: { label: 'uniprot', pageRank: 0.55, toolType: ['Database'] } },
-    { id: 4, label: 'Sample publication (2021)', type: 'Publication', properties: { title: 'Sample publication (2021)', year: 2021, doi: '10.1000/sample', pmid: '12345678' } },
-    { id: 5, label: 'MEGA', type: 'Tool', properties: { label: 'mega', pageRank: 0.18, toolType: ['Tool'] } }
-]
-const mockEdges = [
-    { id: 'e1', source: 1, target: 2, weight: 5, properties: { times: 5, year: 2019 } },
-    { id: 'e2', source: 1, target: 3, weight: 2, properties: { times: 2, year: 2020 } },
-    { id: 'e3', source: 2, target: 4, weight: 3, properties: { times: 3, year: 2021 } },
-    { id: 'e4', source: 5, target: 1, weight: 4, properties: { times: 4, year: 2018 } }
-]
-
 onMounted(() => {
     // Desktop starts with the sidebar open; narrow screens start closed (overlay pattern).
     if (!window.matchMedia('(max-width: 600px)').matches) {
         uiStore.setSidebarOpen(true)
     }
-
-    graphStore.setGraph(mockNodes, mockEdges)
 })
 </script>
 
@@ -117,6 +100,7 @@ onMounted(() => {
 }
 
 .graph-main {
+    position: relative;
     min-height: 100vh;
     transition: margin-left 0.3s ease;
 }
@@ -149,5 +133,17 @@ onMounted(() => {
 
 .graph-canvas {
     height: 100vh;
+}
+
+.graph-empty-state {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 5;
+    color: var(--insolito-text-muted);
+    font-size: 1rem;
+    text-align: center;
+    pointer-events: none;
 }
 </style>

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -6,6 +6,40 @@
       Reset
     </BButton>
 
+    <section class="graph-sidebar-search">
+      <h3 class="graph-sidebar-filter-title">Search</h3>
+      <div class="graph-sidebar-search-input-wrap">
+        <input
+          v-model="searchTerm"
+          type="text"
+          placeholder="blast, 1000Genomes, MEGA..."
+          class="graph-sidebar-search-input"
+          :disabled="searching"
+          autocomplete="off"
+          @focus="showSuggestions = true"
+          @blur="onInputBlur"
+          @keydown="onKeydown"
+        >
+        <ul v-if="showSuggestions && suggestions.length" class="graph-sidebar-suggestions">
+          <li
+            v-for="(suggestion, index) in suggestions"
+            :key="suggestion.name"
+            class="graph-sidebar-suggestion"
+            :class="{ 'graph-sidebar-suggestion-highlighted': index === highlightedIndex }"
+            @mousedown.prevent="onSelectSuggestion(suggestion)"
+            @mouseenter="highlightedIndex = index"
+          >
+            <span class="graph-sidebar-suggestion-name">{{ suggestion.name }}</span>
+            <span class="graph-sidebar-suggestion-kind">{{ suggestion.kind }}</span>
+          </li>
+        </ul>
+        <p v-else-if="showSuggestions && searchTerm.trim()" class="graph-sidebar-suggestions-empty">
+          No matches
+        </p>
+      </div>
+      <p v-if="searchError" class="graph-sidebar-search-error">{{ searchError }}</p>
+    </section>
+
     <section class="graph-sidebar-filter">
       <h3 class="graph-sidebar-filter-title">Publication year</h3>
       <GraphHistogram :values="yearCounts" />
@@ -33,7 +67,7 @@
     </section>
 
     <p class="graph-sidebar-placeholder">
-      Search and legend will appear here.
+      Legend will appear here.
     </p>
   </aside>
 </template>
@@ -48,6 +82,77 @@ defineProps({
 const emit = defineEmits(['reset'])
 
 const filterStore = useFilterStore()
+const graphStore = useGraphStore()
+const { search, loading: searching } = useNeo4jSearch()
+
+const searchTerm = ref('')
+const searchError = ref('')
+const showSuggestions = ref(false)
+const highlightedIndex = ref(-1)
+const suggestions = computed(() => suggestSearchTerms(searchTerm.value))
+
+watch(searchTerm, () => {
+    highlightedIndex.value = -1
+})
+
+function onInputBlur () {
+    // Delayed so a click on a suggestion (mousedown, handled first) still registers
+    // before the list disappears.
+    setTimeout(() => { showSuggestions.value = false }, 150)
+}
+
+function onSelectSuggestion (suggestion) {
+    showSuggestions.value = false
+    runSearch(suggestion)
+}
+
+function onKeydown (event) {
+    if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        if (!suggestions.value.length) return
+        showSuggestions.value = true
+        highlightedIndex.value = Math.min(highlightedIndex.value + 1, suggestions.value.length - 1)
+    } else if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        highlightedIndex.value = Math.max(highlightedIndex.value - 1, -1)
+    } else if (event.key === 'Escape') {
+        showSuggestions.value = false
+        highlightedIndex.value = -1
+    } else if (event.key === 'Enter') {
+        event.preventDefault()
+        showSuggestions.value = false
+        // A highlighted suggestion (arrow keys) wins; otherwise fall back to an
+        // exact-match search for someone who typed the full name from memory.
+        const picked = suggestions.value[highlightedIndex.value]
+        if (picked) {
+            runSearch(picked)
+            return
+        }
+        const resolved = resolveSearchTerm(searchTerm.value)
+        if (!resolved) {
+            searchError.value = `No tool or topic found for "${searchTerm.value}"`
+            return
+        }
+        runSearch(resolved)
+    }
+}
+
+async function runSearch ({ name, kind }) {
+    searchError.value = ''
+    try {
+        const { nodes, edges } = await search({
+            name,
+            kind,
+            occurrenceMin: filterStore.occurrenceMin,
+            yearMin: filterStore.yearMin,
+            yearMax: filterStore.yearMax
+        })
+        graphStore.addToGraph(nodes, edges)
+        searchTerm.value = ''
+    } catch {
+        searchError.value = 'Search failed. Please try again.'
+    }
+}
 
 // Publication year: linear domain, taken straight from the year -> count map.
 const yearEntries = Object.entries(YearData).map(([year, count]) => [Number(year), count]).sort((a, b) => a[0] - b[0])
@@ -80,6 +185,9 @@ function onOccurrenceChange () {
 function onReset () {
     yearRange.value = [yearDomainMin, yearDomainMax]
     occurrenceValue.value = occurrenceDomainMin
+    searchTerm.value = ''
+    searchError.value = ''
+    showSuggestions.value = false
     filterStore.reset()
     emit('reset')
 }
@@ -135,11 +243,114 @@ function onReset () {
     line-height: 1.5;
 }
 
-.graph-sidebar-filter {
+.graph-sidebar-filter,
+.graph-sidebar-search {
     width: 100%;
     display: flex;
     flex-direction: column;
     gap: 8px;
+}
+
+.graph-sidebar-search-input {
+    padding: 6px 10px;
+    border: 1px solid var(--insolito-border);
+    border-radius: 6px;
+    font-size: 0.9rem;
+    color: var(--insolito-text);
+}
+
+.graph-sidebar-search-input:focus {
+    outline: none;
+    border-color: var(--insolito-primary);
+}
+
+.graph-sidebar-search-input-wrap {
+    position: relative;
+    width: 100%;
+}
+
+.graph-sidebar-search-input-wrap .graph-sidebar-search-input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.graph-sidebar-suggestions {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 22;
+    margin: 0;
+    padding: 4px 0;
+    list-style: none;
+    background: var(--insolito-bg);
+    border: 1px solid var(--insolito-border);
+    border-radius: 6px;
+    box-shadow: 0 6px 20px rgba(28, 43, 58, 0.18);
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.graph-sidebar-suggestion {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 7px 10px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    border-left: 3px solid transparent;
+}
+
+.graph-sidebar-suggestion:hover,
+.graph-sidebar-suggestion-highlighted {
+    background: var(--insolito-bg-footer);
+    border-left-color: var(--insolito-primary);
+}
+
+.graph-sidebar-suggestion-name {
+    color: var(--insolito-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.graph-sidebar-suggestion-kind {
+    flex-shrink: 0;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--insolito-bg-footer);
+    color: var(--insolito-text-muted);
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.graph-sidebar-suggestion-highlighted .graph-sidebar-suggestion-kind {
+    background: var(--insolito-bg);
+}
+
+.graph-sidebar-suggestions-empty {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 22;
+    margin: 0;
+    padding: 6px 10px;
+    font-size: 0.82rem;
+    color: var(--insolito-text-muted);
+    background: var(--insolito-bg);
+    border: 1px solid var(--insolito-border);
+    border-radius: 6px;
+    box-shadow: 0 6px 20px rgba(28, 43, 58, 0.18);
+}
+
+.graph-sidebar-search-error {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--insolito-danger);
 }
 
 .graph-sidebar-filter-title {

--- a/FRONTEND-nuxt/app/composables/useNeo4jSearch.js
+++ b/FRONTEND-nuxt/app/composables/useNeo4jSearch.js
@@ -1,0 +1,44 @@
+import neo4jConfig from '../config.json'
+import { buildSearchQuery } from '../utils/cypherQueries'
+import { parseNeo4jGraph } from '../utils/parseNeo4jGraph'
+
+// POSTs a Cypher query to Neo4j's HTTP transactional endpoint. Fixes a bug carried
+// over from the webpack app: `(user + ':' + pass).toString('base64')` is a no-op on
+// String (that method only exists on Node's Buffer), so the old Authorization header
+// was sent unencoded — harmless only because production Neo4j runs with
+// NEO4J_AUTH=none. btoa() here produces real HTTP Basic auth.
+export function useNeo4jSearch () {
+    const loading = ref(false)
+    const error = ref('')
+
+    async function search ({ name, kind, occurrenceMin, yearMin, yearMax }) {
+        loading.value = true
+        error.value = ''
+        try {
+            const { statement, parameters } = buildSearchQuery({ name, kind, occurrenceMin, yearMin, yearMax })
+            const response = await $fetch(neo4jConfig.serverUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json;charset=UTF-8',
+                    'Access-Mode': 'READ',
+                    Authorization: `Basic ${btoa(`${neo4jConfig.serverUser}:${neo4jConfig.serverPassword}`)}`
+                },
+                body: {
+                    statements: [{ statement, parameters, resultDataContents: ['graph'] }]
+                }
+            })
+            if (response.errors?.length) {
+                throw new Error(response.errors[0].message)
+            }
+            return parseNeo4jGraph(response)
+        } catch (e) {
+            error.value = e.message || 'Search failed'
+            throw e
+        } finally {
+            loading.value = false
+        }
+    }
+
+    return { search, loading, error }
+}

--- a/FRONTEND-nuxt/app/config.json
+++ b/FRONTEND-nuxt/app/config.json
@@ -1,0 +1,5 @@
+{
+    "serverUrl": "https://insolito.openebench.bsc.es/db/neo4j/tx",
+    "serverUser": "neo4j",
+    "serverPassword": "1234"
+}

--- a/FRONTEND-nuxt/app/stores/graph.js
+++ b/FRONTEND-nuxt/app/stores/graph.js
@@ -10,10 +10,20 @@ export const useGraphStore = defineStore('graph', () => {
         edges.value = newEdges
     }
 
+    // Merges a search result into the existing graph instead of replacing it,
+    // matching the old app's additive behaviour (searching a second tool adds
+    // its neighbours rather than starting over). Dedupes by Neo4j's node/edge id.
+    function addToGraph (newNodes, newEdges) {
+        const existingNodeIds = new Set(nodes.value.map((node) => node.id))
+        const existingEdgeIds = new Set(edges.value.map((edge) => edge.id))
+        nodes.value = [...nodes.value, ...newNodes.filter((node) => !existingNodeIds.has(node.id))]
+        edges.value = [...edges.value, ...newEdges.filter((edge) => !existingEdgeIds.has(edge.id))]
+    }
+
     function reset () {
         nodes.value = []
         edges.value = []
     }
 
-    return { nodes, edges, setGraph, reset }
+    return { nodes, edges, setGraph, addToGraph, reset }
 })

--- a/FRONTEND-nuxt/app/utils/cypherQueries.js
+++ b/FRONTEND-nuxt/app/utils/cypherQueries.js
@@ -1,0 +1,42 @@
+// Query shape mirrors the Cypher variants documented in CLAUDE.md (Tool/Database
+// search vs Topic search, each with/without a year filter). Publications are
+// always excluded from a Tool/Database search (matches the old app's default,
+// unchecked "Display Articles" state) — a toggle for this is out of scope here,
+// deferred to the layered-visualization roadmap item. Values are always sent as
+// query parameters, not string-concatenated, so a search term can never break
+// out of the Cypher statement.
+const OCCURRENCE_MAX = 100
+
+export function buildSearchQuery ({ name, kind, occurrenceMin, yearMin, yearMax }) {
+    const hasYearFilter = yearMin != null && yearMax != null
+    const relType = hasYearFilter ? 'METAOCCUR' : 'METAOCCUR_ALL'
+    const parameters = { name, cMin: occurrenceMin ?? 0, cMax: OCCURRENCE_MAX }
+    if (hasYearFilter) {
+        parameters.yMin = yearMin
+        parameters.yMax = yearMax
+    }
+
+    if (kind === 'Topic') {
+        const yearClause = hasYearFilter ? ' AND m.year>=$yMin AND m.year<=$yMax' : ''
+        return {
+            statement:
+                'MATCH (n)-[:TOPIC]->(k:Keyword)-[:SUBCLASS*]->(k2:Keyword) ' +
+                'WHERE k2.label=$name OR k.label=$name ' +
+                'WITH DISTINCT n WITH collect(n) AS nt UNWIND nt AS nt1 UNWIND nt AS nt2 ' +
+                `MATCH (nt1)-[m:${relType}]-(nt2) ` +
+                `WHERE m.times>=$cMin AND m.times<=$cMax${yearClause} ` +
+                'RETURN nt1,m,nt2',
+            parameters
+        }
+    }
+
+    // Tool/Database search, matched by exact node name.
+    const yearClause = hasYearFilter ? ' AND o.year>=$yMin AND o.year<=$yMax' : ''
+    return {
+        statement:
+            `MATCH (i)-[o:${relType}]-(p) ` +
+            `WHERE i.name=$name AND o.times>=$cMin AND o.times<=$cMax AND NOT p:Publication${yearClause} ` +
+            'RETURN i,o,p ORDER BY o.times',
+        parameters
+    }
+}

--- a/FRONTEND-nuxt/app/utils/parseNeo4jGraph.js
+++ b/FRONTEND-nuxt/app/utils/parseNeo4jGraph.js
@@ -1,0 +1,29 @@
+// Converts a Neo4j HTTP transactional endpoint response (resultDataContents: ['graph'])
+// into the { nodes, edges } shape graphStore expects. Dedupes by Neo4j's own internal
+// id, same as the old app's idNodesSet/idEdgesSet, since a search can return nodes/edges
+// already present in the graph.
+export function parseNeo4jGraph (response) {
+    const nodesById = new Map()
+    const edgesById = new Map()
+
+    for (const row of response.results[0].data) {
+        for (const node of row.graph.nodes) {
+            if (nodesById.has(node.id)) continue
+            const type = node.labels[0]
+            const label = type === 'Publication' ? node.properties.subtitle : node.properties.name
+            nodesById.set(node.id, { id: node.id, label, type, properties: node.properties })
+        }
+        for (const rel of row.graph.relationships) {
+            if (edgesById.has(rel.id)) continue
+            edgesById.set(rel.id, {
+                id: rel.id,
+                source: rel.startNode,
+                target: rel.endNode,
+                weight: rel.properties.times,
+                properties: rel.properties
+            })
+        }
+    }
+
+    return { nodes: [...nodesById.values()], edges: [...edgesById.values()] }
+}

--- a/FRONTEND-nuxt/app/utils/toolTopicLookup.js
+++ b/FRONTEND-nuxt/app/utils/toolTopicLookup.js
@@ -1,0 +1,44 @@
+import ToolTopicData from '../../../DB/ToolTopicAutocomplete.json'
+
+// Resolves free-typed search text to a known tool/topic name and its kind, by
+// exact (case-insensitive) match against the bundled autocomplete dataset. This
+// also doubles as the search's only validation: text that isn't in the dataset
+// never reaches the Cypher query.
+export function resolveSearchTerm (rawTerm) {
+    const term = rawTerm.trim().toLowerCase()
+    if (!term) return null
+
+    const match = ToolTopicData.find((entry) => entry.value.toLowerCase() === term)
+    if (!match) return null
+
+    const kind = Array.isArray(match.labelnode) ? match.labelnode[0] : match.labelnode
+    return { name: match.value, kind }
+}
+
+// Suggestions for the search box as the user types: prefix matches first, then
+// "contains" matches, same two-pass order as the old jQuery UI autocomplete.
+export function suggestSearchTerms (rawTerm, limit = 8) {
+    const term = rawTerm.trim().toLowerCase()
+    if (!term) return []
+
+    const startsWith = []
+    const contains = []
+    const seen = new Set()
+
+    for (const entry of ToolTopicData) {
+        if (typeof entry.value !== 'string' || seen.has(entry.value)) continue
+        const value = entry.value.toLowerCase()
+        if (value.startsWith(term)) {
+            startsWith.push(entry)
+            seen.add(entry.value)
+        } else if (value.includes(term)) {
+            contains.push(entry)
+            seen.add(entry.value)
+        }
+    }
+
+    return [...startsWith, ...contains].slice(0, limit).map((entry) => ({
+        name: entry.value,
+        kind: Array.isArray(entry.labelnode) ? entry.labelnode[0] : entry.labelnode
+    }))
+}


### PR DESCRIPTION
## Summary

Migrate search input to Vue with real Neo4j queries and autocomplete

## Changes

**New files:**
- `FRONTEND-nuxt/app/config.json` — Neo4j connection config.
- `FRONTEND-nuxt/app/utils/cypherQueries.js` — builds the Tool/Topic Cypher search queries.
- `FRONTEND-nuxt/app/utils/parseNeo4jGraph.js` — parses the Neo4j HTTP response into the store.
- `FRONTEND-nuxt/app/utils/toolTopicLookup.js` — resolves and suggests search terms against `ToolTopicAutocomplete.json`.
- `FRONTEND-nuxt/app/composables/useNeo4jSearch.js` — POSTs the Cypher query to Neo4j.

**Modified files:**
- `FRONTEND-nuxt/app/stores/graph.js` — adds `addToGraph()` to merge search results into the existing graph instead of replacing it.
- `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — replaces the placeholder content with a search input with autocomplete dropdown.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — removes the mock seed data now that real search exists.
- `FRONTEND-nuxt/app/assets/css/main.scss` — adds the `--insolito-danger` color, used for the search error message.

## Issues

Closes #155