### PR TITLE
[REFACTOR] Tune graph layout

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -4,6 +4,9 @@
 
 <script setup>
 import cytoscape from 'cytoscape'
+import fcose from 'cytoscape-fcose'
+
+cytoscape.use(fcose)
 
 const props = defineProps({
     // [{ id, label, type: 'Tool' | 'Database' | 'Publication', properties }]
@@ -43,8 +46,19 @@ function toElements () {
     return [...nodeEls, ...edgeEls]
 }
 
+// nodeRepulsion/idealEdgeLength raised well above fcose's defaults (4500/50):
+// dense hub-and-spoke searches (e.g. "blast", ~150 neighbours) need much more
+// spacing to keep node labels from overlapping around the hub.
+const layoutOptions = {
+    name: 'fcose',
+    animate: false,
+    fit: true,
+    nodeRepulsion: 12000,
+    idealEdgeLength: 150
+}
+
 function runLayout () {
-    cy.layout({ name: 'cose', animate: false, fit: true }).run()
+    cy.layout(layoutOptions).run()
 }
 
 onMounted(() => {
@@ -85,7 +99,7 @@ onMounted(() => {
                 }
             }
         ],
-        layout: { name: 'cose', animate: false }
+        layout: layoutOptions
     })
 
     cy.on('tap', 'node', (event) => {

--- a/FRONTEND-nuxt/package-lock.json
+++ b/FRONTEND-nuxt/package-lock.json
@@ -12,6 +12,7 @@
         "bootstrap": "^5.3.3",
         "bootstrap-vue-next": "^0.45.7",
         "cytoscape": "^3.34.0",
+        "cytoscape-fcose": "^2.2.0",
         "nuxt": "^4.4.8",
         "pinia": "^3.0.4",
         "vue": "^3.5.39",
@@ -5236,6 +5237,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -5498,6 +5508,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
       }
     },
     "node_modules/db0": {
@@ -6775,6 +6797,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.4"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
     },
     "node_modules/lazystream": {
       "version": "1.0.1",

--- a/FRONTEND-nuxt/package.json
+++ b/FRONTEND-nuxt/package.json
@@ -15,6 +15,7 @@
     "bootstrap": "^5.3.3",
     "bootstrap-vue-next": "^0.45.7",
     "cytoscape": "^3.34.0",
+    "cytoscape-fcose": "^2.2.0",
     "nuxt": "^4.4.8",
     "pinia": "^3.0.4",
     "vue": "^3.5.39",


### PR DESCRIPTION
## Summary

Replace cose layout with cytoscape-fcose to reduce node clumping

## Changes

**Modified files:**
- `FRONTEND-nuxt/app/components/graph/Network.vue` — replaces the `cose` layout with `cytoscape-fcose` and tunes `nodeRepulsion` and `idealEdgeLength` above their defaults to keep node labels readable on dense hub-and-spoke searches.
- `FRONTEND-nuxt/package.json` / `package-lock.json` — adds the `cytoscape-fcose` dependency.

## Issues

Closes #157