### PR TITLE
[REFACTOR] Collapsible legend

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Legend.vue
+++ b/FRONTEND-nuxt/app/components/graph/Legend.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="graph-legend">
+    <button
+      class="legend-toggle"
+      :aria-expanded="uiStore.legendOpen"
+      @click="uiStore.toggleLegend()"
+    >
+      <span>Legend</span>
+      <svg
+        viewBox="0 0 24 24"
+        class="legend-chevron"
+        :class="{ 'legend-chevron-collapsed': !uiStore.legendOpen }"
+      >
+        <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
+
+    <ul v-if="uiStore.legendOpen" class="legend-list">
+      <li>
+        <span class="legend-dot legend-dot-tool" />
+        Tool
+      </li>
+      <li>
+        <span class="legend-dot legend-dot-database" />
+        Database
+      </li>
+      <li>
+        <span class="legend-dot legend-dot-publication" />
+        Publication
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+const uiStore = useUiStore()
+</script>
+
+<style scoped>
+.graph-legend {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 18;
+    width: 180px;
+    box-sizing: border-box;
+    background: var(--insolito-bg);
+    border-radius: 8px;
+    border-top: 4px solid var(--insolito-border);
+    box-shadow: 0 6px 24px rgba(28, 43, 58, 0.24);
+    overflow: hidden;
+}
+
+.legend-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--insolito-text);
+}
+
+.legend-chevron {
+    width: 16px;
+    height: 16px;
+    transition: transform 0.2s ease;
+}
+
+.legend-chevron-collapsed {
+    transform: rotate(-90deg);
+}
+
+.legend-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 16px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.legend-list li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--insolito-text);
+}
+
+.legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    border-width: 2px;
+    border-style: solid;
+}
+
+.legend-dot-tool {
+    background: var(--insolito-node-primary);
+    border-color: var(--insolito-primary);
+}
+
+.legend-dot-database {
+    background: var(--insolito-node-tertiary);
+    border-color: var(--insolito-node-tertiary-dark);
+}
+
+.legend-dot-publication {
+    background: var(--insolito-node-secondary);
+    border-color: var(--insolito-secondary-hover);
+}
+
+@media (max-width: 600px) {
+    .graph-legend {
+        /* Clears the toggle button (top:20px, 40px tall) instead of overlapping it */
+        top: 76px;
+        left: 16px;
+        right: 16px;
+        width: auto;
+    }
+}
+</style>

--- a/FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue
+++ b/FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue
@@ -50,7 +50,7 @@ defineEmits(['close'])
 <style scoped>
 .node-info-panel {
     position: fixed;
-    top: 20px;
+    bottom: 20px;
     right: 20px;
     z-index: 18;
     width: 260px;
@@ -76,8 +76,8 @@ defineEmits(['close'])
 
 @media (max-width: 600px) {
     .node-info-panel {
-        /* Clears the toggle button (top:20px, 40px tall) instead of overlapping it */
-        top: 76px;
+        /* Anchored to the bottom, so it never needs to clear the top toggle button */
+        bottom: 16px;
         left: 16px;
         right: 16px;
         width: auto;

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -17,6 +17,7 @@
     </button>
 
     <main class="graph-main" :class="uiStore.sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
+      <GraphLegend />
       <GraphNodeInfoPanel v-if="selectedNode" :node="selectedNode" @close="selectedNode = null" />
       <p v-if="graphStore.nodes.length === 0" class="graph-empty-state">
         Search for a tool or topic in the sidebar to get started.

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -1,5 +1,6 @@
 export const useUiStore = defineStore('ui', () => {
     const sidebarOpen = ref(false)
+    const legendOpen = ref(true)
 
     function toggleSidebar () {
         sidebarOpen.value = !sidebarOpen.value
@@ -9,5 +10,9 @@ export const useUiStore = defineStore('ui', () => {
         sidebarOpen.value = open
     }
 
-    return { sidebarOpen, toggleSidebar, setSidebarOpen }
+    function toggleLegend () {
+        legendOpen.value = !legendOpen.value
+    }
+
+    return { sidebarOpen, toggleSidebar, setSidebarOpen, legendOpen, toggleLegend }
 })


### PR DESCRIPTION
## Summary

Add collapsible legend widget and reposition NodeInfoPanel to bottom-right

## Changes

**New files:**
- `FRONTEND-nuxt/app/components/graph/Legend.vue` — collapsible floating legend.

**Modified files:**
- `FRONTEND-nuxt/app/stores/ui.js` — adds `legendOpen` (default `true`) state and the `toggleLegend()` action.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — mounts the new `Legend` component.
- `FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue` — moves the panel from the top-right to the bottom-right.
## Issues

Closes #159