### PR TITLE
[REFACTOR] Graph export

### DIFF
--- a/FRONTEND-nuxt/app/assets/css/main.scss
+++ b/FRONTEND-nuxt/app/assets/css/main.scss
@@ -46,6 +46,17 @@ body {
     border-color: var(--insolito-primary);
 }
 
+.btn-outline-secondary {
+    color: var(--insolito-text-muted);
+    border-color: var(--insolito-border);
+}
+
+.btn-outline-secondary:hover {
+    background-color: var(--insolito-bg-footer);
+    border-color: var(--insolito-border);
+    color: var(--insolito-text);
+}
+
 a {
     color: var(--insolito-primary);
 }

--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -61,6 +61,14 @@ function runLayout () {
     cy.layout(layoutOptions).run()
 }
 
+// bg is passed explicitly because cy.png() renders on an offscreen canvas
+// with a transparent background by default, not the page's CSS.
+function exportPng () {
+    return cy.png({ full: true, scale: 2, bg: cssVar('--insolito-bg') })
+}
+
+defineExpose({ exportPng })
+
 onMounted(() => {
     nodeColor = {
         Tool: cssVar('--insolito-node-primary'),

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="graph-screen">
-    <GraphSidebar :open="uiStore.sidebarOpen" @reset="onReset" />
+    <GraphSidebar :open="uiStore.sidebarOpen" @reset="onReset" @export-png="onExportPng" />
 
     <div v-if="uiStore.sidebarOpen" class="sidebar-backdrop" @click="uiStore.setSidebarOpen(false)" />
 
@@ -17,12 +17,13 @@
     </button>
 
     <main class="graph-main" :class="uiStore.sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
-      <GraphLegend />
+      <GraphLegend v-if="graphStore.nodes.length" />
       <GraphNodeInfoPanel v-if="selectedNode" :node="selectedNode" @close="selectedNode = null" />
       <p v-if="graphStore.nodes.length === 0" class="graph-empty-state">
         Search for a tool or topic in the sidebar to get started.
       </p>
       <GraphNetwork
+        ref="networkRef"
         :nodes="graphStore.nodes"
         :edges="graphStore.edges"
         class="graph-canvas"
@@ -38,10 +39,16 @@ const graphStore = useGraphStore()
 const uiStore = useUiStore()
 
 const selectedNode = ref(null)
+const networkRef = ref(null)
 
 function onReset () {
     graphStore.reset()
     selectedNode.value = null
+}
+
+function onExportPng () {
+    const dataUri = networkRef.value?.exportPng()
+    if (dataUri) downloadDataUri(dataUri, 'InSoLiTo-network.png')
 }
 
 onMounted(() => {

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -66,9 +66,17 @@
       <p class="graph-sidebar-filter-value">{{ occurrenceValue }}</p>
     </section>
 
-    <p class="graph-sidebar-placeholder">
-      Legend will appear here.
-    </p>
+    <section v-if="graphStore.nodes.length" class="graph-sidebar-export">
+      <h3 class="graph-sidebar-filter-title">Export</h3>
+      <div class="graph-sidebar-export-buttons">
+        <BButton variant="outline-secondary" size="sm" @click="$emit('export-png')">
+          PNG
+        </BButton>
+        <BButton variant="outline-secondary" size="sm" @click="onExportJson">
+          JSON
+        </BButton>
+      </div>
+    </section>
   </aside>
 </template>
 
@@ -79,7 +87,7 @@ import OccurData from '../../../../DB/RelationshipSliderData.json'
 defineProps({
     open: { type: Boolean, default: true }
 })
-const emit = defineEmits(['reset'])
+const emit = defineEmits(['reset', 'export-png'])
 
 const filterStore = useFilterStore()
 const graphStore = useGraphStore()
@@ -182,6 +190,10 @@ function onOccurrenceChange () {
     filterStore.setFilters(yearRange.value[0], yearRange.value[1], occurrenceValue.value)
 }
 
+function onExportJson () {
+    downloadGraphAsJson(graphStore.nodes, graphStore.edges)
+}
+
 function onReset () {
     yearRange.value = [yearDomainMin, yearDomainMax]
     occurrenceValue.value = occurrenceDomainMin
@@ -237,10 +249,20 @@ function onReset () {
     border-color: var(--insolito-primary-dark);
 }
 
-.graph-sidebar-placeholder {
-    color: var(--insolito-text-muted);
-    font-size: 0.9rem;
-    line-height: 1.5;
+.graph-sidebar-export {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.graph-sidebar-export-buttons {
+    display: flex;
+    gap: 8px;
+}
+
+.graph-sidebar-export-buttons .btn {
+    flex: 1;
 }
 
 .graph-sidebar-filter,

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -1,6 +1,6 @@
 export const useUiStore = defineStore('ui', () => {
     const sidebarOpen = ref(false)
-    const legendOpen = ref(true)
+    const legendOpen = ref(false)
 
     function toggleSidebar () {
         sidebarOpen.value = !sidebarOpen.value

--- a/FRONTEND-nuxt/app/utils/exportGraph.js
+++ b/FRONTEND-nuxt/app/utils/exportGraph.js
@@ -1,0 +1,19 @@
+function triggerDownload (href, filename) {
+    const link = document.createElement('a')
+    link.href = href
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+}
+
+export function downloadDataUri (dataUri, filename) {
+    triggerDownload(dataUri, filename)
+}
+
+export function downloadGraphAsJson (nodes, edges) {
+    const blob = new Blob([JSON.stringify({ nodes, edges }, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    triggerDownload(url, 'InSoLiTo-graph.json')
+    URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary

Add PNG and JSON graph export

## Changes

**New files:**
- `FRONTEND-nuxt/app/utils/exportGraph.js` — download helpers for the PNG data URI and the JSON blob.

**Modified files:**
- `FRONTEND-nuxt/app/components/graph/Network.vue` — exposes `exportPng()` via `defineExpose`, using Cytoscape's built-in `cy.png()`.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — holds a template ref to `GraphNetwork` to trigger the PNG download from the sidebar.
- `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — adds an **Export** section (PNG/JSON buttons) at the bottom, shown only once a search has produced a graph.
- `FRONTEND-nuxt/app/stores/ui.js` — changes `legendOpen` default from `true` to `false`.
- `FRONTEND-nuxt/app/assets/css/main.scss` — adds a neutral `.btn-outline-secondary` override for the export buttons.

## Issues

Closes #161