### PR TITLE
[REFACTOR] Color mode toggle

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Legend.vue
+++ b/FRONTEND-nuxt/app/components/graph/Legend.vue
@@ -1,21 +1,45 @@
 <template>
   <div class="graph-legend">
-    <button
-      class="legend-toggle"
-      :aria-expanded="uiStore.legendOpen"
-      @click="uiStore.toggleLegend()"
-    >
-      <span>Legend</span>
-      <svg
-        viewBox="0 0 24 24"
-        class="legend-chevron"
-        :class="{ 'legend-chevron-collapsed': !uiStore.legendOpen }"
+    <div class="legend-header">
+      <div class="legend-mode-toggle" role="tablist" aria-label="Legend color mode">
+        <button
+          type="button"
+          role="tab"
+          class="legend-mode-btn"
+          :class="{ 'legend-mode-btn-active': uiStore.colorMode === 'type' }"
+          :aria-selected="uiStore.colorMode === 'type'"
+          @click="uiStore.setColorMode('type')"
+        >
+          By type
+        </button>
+        <button
+          type="button"
+          role="tab"
+          class="legend-mode-btn"
+          :class="{ 'legend-mode-btn-active': uiStore.colorMode === 'topic' }"
+          :aria-selected="uiStore.colorMode === 'topic'"
+          @click="uiStore.setColorMode('topic')"
+        >
+          By topic
+        </button>
+      </div>
+      <button
+        class="legend-collapse-btn"
+        :aria-expanded="uiStore.legendOpen"
+        aria-label="Toggle legend"
+        @click="uiStore.toggleLegend()"
       >
-        <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      </svg>
-    </button>
+        <svg
+          viewBox="0 0 24 24"
+          class="legend-chevron"
+          :class="{ 'legend-chevron-collapsed': !uiStore.legendOpen }"
+        >
+          <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
+    </div>
 
-    <ul v-if="uiStore.legendOpen" class="legend-list">
+    <ul v-if="uiStore.legendOpen && uiStore.colorMode === 'type'" class="legend-list">
       <li>
         <span class="legend-dot legend-dot-tool" />
         Tool
@@ -29,11 +53,47 @@
         Publication
       </li>
     </ul>
+
+    <ul v-else-if="uiStore.legendOpen" class="legend-list">
+      <li v-for="entry in topicEntries" :key="entry.id">
+        <span class="legend-dot" :style="{ background: entry.bg, borderColor: entry.border }" />
+        {{ entry.label }}
+      </li>
+      <li v-if="topicEntries.length === 0" class="legend-empty">
+        No clusters to show yet.
+      </li>
+    </ul>
   </div>
 </template>
 
 <script setup>
 const uiStore = useUiStore()
+const graphStore = useGraphStore()
+
+// Colors come from clusterPalette's buildClusterColorMap (same helper Network.vue uses)
+// so a community's swatch here always matches its color on the canvas — every
+// community present gets its own reproducible color, sorted by node count
+// (largest cluster first), matching the old app's cluster legend.
+const topicEntries = computed(() => {
+    const nodes = graphStore.nodes
+    const colorMap = buildClusterColorMap(nodes)
+    const counts = {}
+    nodes.forEach((node) => {
+        const id = node.properties?.community
+        if (id === undefined || id === null) return
+        counts[id] = (counts[id] || 0) + 1
+    })
+
+    return Object.entries(counts)
+        .map(([id, count]) => ({
+            id,
+            label: communityTopicById[id] || `Cluster ${id}`,
+            count,
+            bg: colorMap[id].bg,
+            border: colorMap[id].border
+        }))
+        .sort((a, b) => b.count - a.count)
+})
 </script>
 
 <style scoped>
@@ -42,7 +102,7 @@ const uiStore = useUiStore()
     top: 20px;
     right: 20px;
     z-index: 18;
-    width: 180px;
+    width: 220px;
     box-sizing: border-box;
     background: var(--insolito-bg);
     border-radius: 8px;
@@ -51,17 +111,50 @@ const uiStore = useUiStore()
     overflow: hidden;
 }
 
-.legend-toggle {
-    width: 100%;
+.legend-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 14px 16px;
+    gap: 4px;
+    padding: 8px;
+}
+
+.legend-mode-toggle {
+    flex: 1;
+    display: flex;
+    gap: 2px;
+    background: var(--insolito-bg-footer);
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.legend-mode-btn {
+    flex: 1;
+    padding: 5px 6px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--insolito-text-muted);
+    white-space: nowrap;
+}
+
+.legend-mode-btn-active {
+    background: var(--insolito-primary);
+    color: white;
+}
+
+.legend-collapse-btn {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 0.85rem;
-    font-weight: 600;
     color: var(--insolito-text);
 }
 
@@ -82,6 +175,8 @@ const uiStore = useUiStore()
     display: flex;
     flex-direction: column;
     gap: 8px;
+    max-height: 220px;
+    overflow-y: auto;
 }
 
 .legend-list li {
@@ -90,6 +185,11 @@ const uiStore = useUiStore()
     gap: 8px;
     font-size: 0.85rem;
     color: var(--insolito-text);
+}
+
+.legend-empty {
+    color: var(--insolito-text-muted);
+    font-size: 0.82rem;
 }
 
 .legend-dot {

--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -12,7 +12,9 @@ const props = defineProps({
     // [{ id, label, type: 'Tool' | 'Database' | 'Publication', properties }]
     nodes: { type: Array, default: () => [] },
     // [{ id, source, target, weight, properties }]
-    edges: { type: Array, default: () => [] }
+    edges: { type: Array, default: () => [] },
+    // 'type' colors by Tool/Database/Publication; 'topic' colors by Louvain community.
+    colorMode: { type: String, default: 'type' }
 })
 
 const emit = defineEmits(['node-click', 'background-click'])
@@ -21,6 +23,9 @@ const containerEl = ref(null)
 let cy = null
 let nodeColor = {}
 let nodeBorderColor = {}
+// community id -> { bg, border } hsl() strings from clusterPalette, one per community
+// currently in the graph. Rebuilt whenever the node set changes.
+let clusterColors = {}
 
 // Canvas fillStyle can't resolve CSS var(), so the custom properties from
 // main.scss are read once and mirrored into plain hex values here.
@@ -81,6 +86,8 @@ onMounted(() => {
         Publication: cssVar('--insolito-secondary-hover')
     }
 
+    clusterColors = buildClusterColorMap(props.nodes)
+
     cy = cytoscape({
         container: containerEl.value,
         elements: toElements(),
@@ -88,9 +95,19 @@ onMounted(() => {
             {
                 selector: 'node',
                 style: {
-                    'background-color': (el) => nodeColor[el.data('type')] || '#999999',
+                    'background-color': (el) => {
+                        if (props.colorMode === 'topic') {
+                            return clusterColors[el.data('properties')?.community]?.bg || '#999999'
+                        }
+                        return nodeColor[el.data('type')] || '#999999'
+                    },
                     'border-width': 2,
-                    'border-color': (el) => nodeBorderColor[el.data('type')] || '#666666',
+                    'border-color': (el) => {
+                        if (props.colorMode === 'topic') {
+                            return clusterColors[el.data('properties')?.community]?.border || '#666666'
+                        }
+                        return nodeBorderColor[el.data('type')] || '#666666'
+                    },
                     label: 'data(label)',
                     'font-size': 12,
                     color: cssVar('--insolito-text'),
@@ -123,10 +140,17 @@ onMounted(() => {
 
 watch([() => props.nodes, () => props.edges], () => {
     if (!cy) return
+    clusterColors = buildClusterColorMap(props.nodes)
     cy.elements().remove()
     cy.add(toElements())
     runLayout()
 }, { deep: true })
+
+// Style functions read props.colorMode directly, but Cytoscape only re-evaluates them
+// on its own triggers (data/element changes) — switching modes needs an explicit nudge.
+watch(() => props.colorMode, () => {
+    cy?.style().update()
+})
 
 onUnmounted(() => {
     cy?.destroy()

--- a/FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue
+++ b/FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue
@@ -8,6 +8,10 @@
       <p class="node-info-type">Publication</p>
       <h3 class="node-info-title">{{ node.properties?.title || node.label }}</h3>
       <p v-if="node.properties?.year" class="node-info-meta">{{ node.properties.year }}</p>
+      <p v-if="communityLabel" class="node-info-meta node-info-community">
+        <span class="node-info-community-dot" :style="{ background: communityColor.bg, borderColor: communityColor.border }" />
+        {{ communityLabel }}
+      </p>
       <div class="node-info-links">
         <a
           v-if="node.properties?.doi"
@@ -27,6 +31,10 @@
     <template v-else>
       <p class="node-info-type">{{ node.type }}</p>
       <h3 class="node-info-title">{{ node.label }}</h3>
+      <p v-if="communityLabel" class="node-info-meta node-info-community">
+        <span class="node-info-community-dot" :style="{ background: communityColor.bg, borderColor: communityColor.border }" />
+        {{ communityLabel }}
+      </p>
       <div class="node-info-links">
         <a
           v-if="node.properties?.label"
@@ -40,11 +48,19 @@
 </template>
 
 <script setup>
-defineProps({
+const props = defineProps({
     // { id, label, type: 'Tool' | 'Database' | 'Publication', properties }
     node: { type: Object, required: true }
 })
 defineEmits(['close'])
+
+const communityLabel = computed(() => {
+    const id = props.node.properties?.community
+    if (id === undefined || id === null) return null
+    return communityTopicById[id] || `Cluster ${id}`
+})
+
+const communityColor = computed(() => getCommunityColor(props.node.properties?.community))
 </script>
 
 <style scoped>
@@ -119,6 +135,22 @@ defineEmits(['close'])
     margin: 0 0 12px;
     font-size: 0.85rem;
     color: var(--insolito-text-muted);
+}
+
+.node-info-community {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.node-info-community-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    border-width: 2px;
+    border-style: solid;
 }
 
 .node-info-links {

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -26,6 +26,7 @@
         ref="networkRef"
         :nodes="graphStore.nodes"
         :edges="graphStore.edges"
+        :color-mode="uiStore.colorMode"
         class="graph-canvas"
         @node-click="selectedNode = $event"
         @background-click="selectedNode = null"

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -1,6 +1,9 @@
 export const useUiStore = defineStore('ui', () => {
     const sidebarOpen = ref(false)
     const legendOpen = ref(false)
+    // 'type' colors nodes by Tool/Database/Publication; 'topic' colors them by
+    // their Louvain community (shared with Network.vue and Legend.vue).
+    const colorMode = ref('type')
 
     function toggleSidebar () {
         sidebarOpen.value = !sidebarOpen.value
@@ -14,5 +17,9 @@ export const useUiStore = defineStore('ui', () => {
         legendOpen.value = !legendOpen.value
     }
 
-    return { sidebarOpen, toggleSidebar, setSidebarOpen, legendOpen, toggleLegend }
+    function setColorMode (mode) {
+        colorMode.value = mode
+    }
+
+    return { sidebarOpen, toggleSidebar, setSidebarOpen, legendOpen, toggleLegend, colorMode, setColorMode }
 })

--- a/FRONTEND-nuxt/app/utils/clusterPalette.js
+++ b/FRONTEND-nuxt/app/utils/clusterPalette.js
@@ -1,0 +1,40 @@
+// Deterministic pseudo-random hash: same seed always maps to the same value in
+// [0, 1). Classic sin-based hash (same trick used for GLSL noise) — not for
+// security, just a stable, well-distributed number from an arbitrary seed.
+function hashToUnitInterval (seed) {
+    const x = Math.sin(seed) * 43758.5453
+    return x - Math.floor(x)
+}
+
+// A community's color depends only on its id — the same id always renders the same
+// color, in the legend, on the canvas, or in the node info panel, regardless of what
+// else is in the graph at the time. Hue/saturation/lightness use different multipliers
+// so the three don't move together, reducing (though not eliminating) the chance that
+// two arbitrary ids happen to look alike side by side.
+function communityColor (id) {
+    const hue = Math.floor(hashToUnitInterval(id * 12.9898) * 360)
+    const saturation = 42 + Math.floor(hashToUnitInterval(id * 78.233) * 18) // 42-60%
+    const lightness = 44 + Math.floor(hashToUnitInterval(id * 39.346) * 16) // 44-60%
+    return {
+        bg: `hsl(${hue}, ${saturation}%, ${lightness}%)`,
+        border: `hsl(${hue}, ${saturation + 4}%, ${Math.max(lightness - 20, 22)}%)`
+    }
+}
+
+// community id -> { bg, border } CSS color strings, one entry per distinct community
+// present in `nodes`.
+export function buildClusterColorMap (nodes) {
+    const colorMap = {}
+    nodes.forEach((node) => {
+        const id = node.properties?.community
+        if (id === undefined || id === null || colorMap[id]) return
+        colorMap[id] = communityColor(id)
+    })
+    return colorMap
+}
+
+// Single-id variant for callers that only need one community's color (e.g. the node
+// info panel), without building a map over the whole graph.
+export function getCommunityColor (id) {
+    return communityColor(id)
+}

--- a/FRONTEND-nuxt/app/utils/communityTopics.js
+++ b/FRONTEND-nuxt/app/utils/communityTopics.js
@@ -1,0 +1,11 @@
+import CommunityData from '../../../DB/CommunityData.json'
+
+// community id -> dominant EDAM topic across that community's tools (see CLAUDE.md,
+// "Data Integration Pipeline" — Louvain groups purely by co-citation density, EDAM is
+// only used afterwards to label the result). Shared by Legend.vue and NodeInfoPanel.vue
+// so both show the exact same label for a given community.
+export const communityTopicById = Object.fromEntries(
+    CommunityData
+        .filter((community) => community && community.id !== undefined)
+        .map((community) => [community.id, community.Topic || 'Unknown'])
+)


### PR DESCRIPTION
## Summary

Add a By type/By topic color mode toggle to the Legend

## Changes

**New files:**
- `FRONTEND-nuxt/app/utils/clusterPalette.js` — deterministic per-community color generation based on the community ID.
- `FRONTEND-nuxt/app/utils/communityTopics.js` — shared community ID → dominant EDAM topic lookup from `CommunityData.json`, used by both `Legend.vue` and `NodeInfoPanel.vue`.

**Modified files:**
- `FRONTEND-nuxt/app/stores/ui.js` — adds `colorMode` state and the `setColorMode()` action.
- `FRONTEND-nuxt/app/components/graph/Network.vue` — adds a `colorMode` prop and switches node colors between type-based and community-based palettes.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — passes `uiStore.colorMode` to `GraphNetwork`.
- `FRONTEND-nuxt/app/components/graph/Legend.vue` — replaces the header with a **By type**/**By topic** toggle.
- `FRONTEND-nuxt/app/components/graph/NodeInfoPanel.vue` — displays each node's community with its topic label and color indicator.

## Issues

Closes #163