### PR TITLE
[REFACTOR] Toggle graph layers from the legend

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Legend.vue
+++ b/FRONTEND-nuxt/app/components/graph/Legend.vue
@@ -40,24 +40,32 @@
     </div>
 
     <ul v-if="uiStore.legendOpen && uiStore.colorMode === 'type'" class="legend-list">
-      <li>
-        <span class="legend-dot legend-dot-tool" />
-        Tool
-      </li>
-      <li>
-        <span class="legend-dot legend-dot-database" />
-        Database
-      </li>
-      <li>
-        <span class="legend-dot legend-dot-publication" />
-        Publication
+      <li v-for="type in TYPE_ENTRIES" :key="type.value">
+        <button
+          type="button"
+          class="legend-item"
+          :class="{ 'legend-item-hidden': uiStore.hiddenTypes.includes(type.value) }"
+          :aria-pressed="!uiStore.hiddenTypes.includes(type.value)"
+          @click="uiStore.toggleHiddenType(type.value)"
+        >
+          <span class="legend-dot" :class="`legend-dot-${type.value.toLowerCase()}`" />
+          {{ type.label }}
+        </button>
       </li>
     </ul>
 
     <ul v-else-if="uiStore.legendOpen" class="legend-list">
       <li v-for="entry in topicEntries" :key="entry.id">
-        <span class="legend-dot" :style="{ background: entry.bg, borderColor: entry.border }" />
-        {{ entry.label }}
+        <button
+          type="button"
+          class="legend-item"
+          :class="{ 'legend-item-hidden': uiStore.hiddenCommunities.includes(entry.id) }"
+          :aria-pressed="!uiStore.hiddenCommunities.includes(entry.id)"
+          @click="uiStore.toggleHiddenCommunity(entry.id)"
+        >
+          <span class="legend-dot" :style="{ background: entry.bg, borderColor: entry.border }" />
+          {{ entry.label }}
+        </button>
       </li>
       <li v-if="topicEntries.length === 0" class="legend-empty">
         No clusters to show yet.
@@ -69,6 +77,12 @@
 <script setup>
 const uiStore = useUiStore()
 const graphStore = useGraphStore()
+
+const TYPE_ENTRIES = [
+    { value: 'Tool', label: 'Tool' },
+    { value: 'Database', label: 'Database' },
+    { value: 'Publication', label: 'Publication' }
+]
 
 // Colors come from clusterPalette's buildClusterColorMap (same helper Network.vue uses)
 // so a community's swatch here always matches its color on the canvas — every
@@ -86,7 +100,10 @@ const topicEntries = computed(() => {
 
     return Object.entries(counts)
         .map(([id, count]) => ({
-            id,
+            // Object.entries gives string keys — normalized back to a number so
+            // uiStore.hiddenCommunities.includes(entry.id) matches node.properties.community
+            // (Array#includes uses strict equality, unlike plain-object key lookups above).
+            id: Number(id),
             label: communityTopicById[id] || `Cluster ${id}`,
             count,
             bg: colorMap[id].bg,
@@ -179,12 +196,29 @@ const topicEntries = computed(() => {
     overflow-y: auto;
 }
 
-.legend-list li {
+.legend-item {
+    width: 100%;
     display: flex;
     align-items: center;
     gap: 8px;
+    padding: 3px 4px;
+    border: none;
+    border-radius: 4px;
+    background: none;
     font-size: 0.85rem;
     color: var(--insolito-text);
+    text-align: left;
+    cursor: pointer;
+    opacity: 1;
+    transition: opacity 0.15s ease;
+}
+
+.legend-item:hover {
+    background: var(--insolito-bg-footer);
+}
+
+.legend-item-hidden {
+    opacity: 0.4;
 }
 
 .legend-empty {

--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -14,7 +14,12 @@ const props = defineProps({
     // [{ id, source, target, weight, properties }]
     edges: { type: Array, default: () => [] },
     // 'type' colors by Tool/Database/Publication; 'topic' colors by Louvain community.
-    colorMode: { type: String, default: 'type' }
+    colorMode: { type: String, default: 'type' },
+    hiddenTypes: { type: Array, default: () => [] },
+    hiddenCommunities: { type: Array, default: () => [] },
+    // Nodes actually searched for (not just pulled in as a neighbour) — always
+    // visible and always colored the same way, regardless of colorMode.
+    entryPointIds: { type: Array, default: () => [] }
 })
 
 const emit = defineEmits(['node-click', 'background-click'])
@@ -74,16 +79,32 @@ function exportPng () {
 
 defineExpose({ exportPng })
 
+// Toggles a class instead of removing elements, so hiding/showing a layer never
+// re-triggers the layout — nodes stay exactly where they were. An edge is hidden
+// whenever either endpoint is, regardless of the edge's own data.
+function isEntryPoint (el) {
+    return props.entryPointIds.includes(el.data('id'))
+}
+
+function applyVisibility () {
+    if (!cy) return
+    const visibility = { hiddenTypes: props.hiddenTypes, hiddenCommunities: props.hiddenCommunities, entryPointIds: props.entryPointIds }
+    cy.batch(() => {
+        cy.nodes().forEach((node) => {
+            const hidden = isNodeHidden({ id: node.data('id'), type: node.data('type'), properties: node.data('properties') }, visibility)
+            node.toggleClass('layer-hidden', hidden)
+        })
+        cy.edges().forEach((edge) => {
+            edge.toggleClass('layer-hidden', edge.source().hasClass('layer-hidden') || edge.target().hasClass('layer-hidden'))
+        })
+    })
+}
+
 onMounted(() => {
-    nodeColor = {
-        Tool: cssVar('--insolito-node-primary'),
-        Database: cssVar('--insolito-node-tertiary'),
-        Publication: cssVar('--insolito-node-secondary')
-    }
-    nodeBorderColor = {
-        Tool: cssVar('--insolito-primary'),
-        Database: cssVar('--insolito-node-tertiary-dark'),
-        Publication: cssVar('--insolito-secondary-hover')
+    for (const type of ['Tool', 'Database', 'Publication']) {
+        const color = getTypeColor(type)
+        nodeColor[type] = color.bg
+        nodeBorderColor[type] = color.border
     }
 
     clusterColors = buildClusterColorMap(props.nodes)
@@ -101,15 +122,21 @@ onMounted(() => {
                         }
                         return nodeColor[el.data('type')] || '#999999'
                     },
-                    'border-width': 2,
                     'border-color': (el) => {
                         if (props.colorMode === 'topic') {
                             return clusterColors[el.data('properties')?.community]?.border || '#666666'
                         }
                         return nodeBorderColor[el.data('type')] || '#666666'
                     },
+                    // Entry points stand out via a slightly bigger size + a slightly
+                    // wider single border + bolder/bigger label — same fill color
+                    // (type/topic) as every other node.
+                    'border-width': (el) => (isEntryPoint(el) ? 4 : 2),
+                    width: (el) => (isEntryPoint(el) ? 40 : 34),
+                    height: (el) => (isEntryPoint(el) ? 40 : 34),
                     label: 'data(label)',
-                    'font-size': 12,
+                    'font-size': (el) => (isEntryPoint(el) ? 14 : 12),
+                    'font-weight': (el) => (isEntryPoint(el) ? 'bold' : 'normal'),
                     color: cssVar('--insolito-text'),
                     'text-valign': 'bottom',
                     'text-margin-y': 6
@@ -122,6 +149,10 @@ onMounted(() => {
                     'line-color': cssVar('--insolito-edge'),
                     'curve-style': 'bezier'
                 }
+            },
+            {
+                selector: '.layer-hidden',
+                style: { display: 'none' }
             }
         ],
         layout: layoutOptions
@@ -136,6 +167,8 @@ onMounted(() => {
             emit('background-click')
         }
     })
+
+    applyVisibility()
 })
 
 watch([() => props.nodes, () => props.edges], () => {
@@ -144,13 +177,25 @@ watch([() => props.nodes, () => props.edges], () => {
     cy.elements().remove()
     cy.add(toElements())
     runLayout()
+    applyVisibility()
 }, { deep: true })
 
 // Style functions read props.colorMode directly, but Cytoscape only re-evaluates them
 // on its own triggers (data/element changes) — switching modes needs an explicit nudge.
 watch(() => props.colorMode, () => {
     cy?.style().update()
+    applyVisibility()
 })
+
+watch([() => props.hiddenTypes, () => props.hiddenCommunities], () => {
+    applyVisibility()
+}, { deep: true })
+
+// entryPointIds affects both which nodes are exempt from hiding and their color.
+watch(() => props.entryPointIds, () => {
+    cy?.style().update()
+    applyVisibility()
+}, { deep: true })
 
 onUnmounted(() => {
     cy?.destroy()

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -27,6 +27,9 @@
         :nodes="graphStore.nodes"
         :edges="graphStore.edges"
         :color-mode="uiStore.colorMode"
+        :hidden-types="uiStore.hiddenTypes"
+        :hidden-communities="uiStore.hiddenCommunities"
+        :entry-point-ids="graphStore.entryPointIds"
         class="graph-canvas"
         @node-click="selectedNode = $event"
         @background-click="selectedNode = null"
@@ -44,6 +47,7 @@ const networkRef = ref(null)
 
 function onReset () {
     graphStore.reset()
+    uiStore.resetLayers()
     selectedNode.value = null
 }
 

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -91,6 +91,7 @@ const emit = defineEmits(['reset', 'export-png'])
 
 const filterStore = useFilterStore()
 const graphStore = useGraphStore()
+const uiStore = useUiStore()
 const { search, loading: searching } = useNeo4jSearch()
 
 const searchTerm = ref('')
@@ -148,14 +149,14 @@ function onKeydown (event) {
 async function runSearch ({ name, kind }) {
     searchError.value = ''
     try {
-        const { nodes, edges } = await search({
+        const { nodes, edges, entryPointId } = await search({
             name,
             kind,
             occurrenceMin: filterStore.occurrenceMin,
             yearMin: filterStore.yearMin,
             yearMax: filterStore.yearMax
         })
-        graphStore.addToGraph(nodes, edges)
+        graphStore.addToGraph(nodes, edges, entryPointId)
         searchTerm.value = ''
     } catch {
         searchError.value = 'Search failed. Please try again.'
@@ -191,7 +192,9 @@ function onOccurrenceChange () {
 }
 
 function onExportJson () {
-    downloadGraphAsJson(graphStore.nodes, graphStore.edges)
+    const visibility = { hiddenTypes: uiStore.hiddenTypes, hiddenCommunities: uiStore.hiddenCommunities, entryPointIds: graphStore.entryPointIds }
+    const { nodes, edges } = filterVisibleGraph(graphStore.nodes, graphStore.edges, visibility)
+    downloadGraphAsJson(nodes, edges)
 }
 
 function onReset () {

--- a/FRONTEND-nuxt/app/composables/useNeo4jSearch.js
+++ b/FRONTEND-nuxt/app/composables/useNeo4jSearch.js
@@ -31,7 +31,11 @@ export function useNeo4jSearch () {
             if (response.errors?.length) {
                 throw new Error(response.errors[0].message)
             }
-            return parseNeo4jGraph(response)
+            const { nodes, edges } = parseNeo4jGraph(response)
+            // Topic searches match a whole set of tools via the EDAM hierarchy, not one
+            // specific node — there's no single "entry point" to highlight for those.
+            const entryPointId = kind === 'Topic' ? null : nodes.find((node) => node.properties?.name === name)?.id ?? null
+            return { nodes, edges, entryPointId }
         } catch (e) {
             error.value = e.message || 'Search failed'
             throw e

--- a/FRONTEND-nuxt/app/stores/graph.js
+++ b/FRONTEND-nuxt/app/stores/graph.js
@@ -4,6 +4,9 @@ export const useGraphStore = defineStore('graph', () => {
     // require redesigning the store.
     const nodes = ref([])
     const edges = ref([])
+    // ids of nodes that were an actual search target (not just pulled in as a
+    // neighbour) — accumulates across searches, same additive spirit as nodes/edges.
+    const entryPointIds = ref([])
 
     function setGraph (newNodes, newEdges) {
         nodes.value = newNodes
@@ -13,17 +16,24 @@ export const useGraphStore = defineStore('graph', () => {
     // Merges a search result into the existing graph instead of replacing it,
     // matching the old app's additive behaviour (searching a second tool adds
     // its neighbours rather than starting over). Dedupes by Neo4j's node/edge id.
-    function addToGraph (newNodes, newEdges) {
+    // entryPointId is tracked separately from the dedup above: a node already in the
+    // graph as someone else's neighbour can later become an entry point in its own
+    // right, and that has to register even though the node object itself isn't "new".
+    function addToGraph (newNodes, newEdges, entryPointId) {
         const existingNodeIds = new Set(nodes.value.map((node) => node.id))
         const existingEdgeIds = new Set(edges.value.map((edge) => edge.id))
         nodes.value = [...nodes.value, ...newNodes.filter((node) => !existingNodeIds.has(node.id))]
         edges.value = [...edges.value, ...newEdges.filter((edge) => !existingEdgeIds.has(edge.id))]
+        if (entryPointId !== undefined && entryPointId !== null && !entryPointIds.value.includes(entryPointId)) {
+            entryPointIds.value = [...entryPointIds.value, entryPointId]
+        }
     }
 
     function reset () {
         nodes.value = []
         edges.value = []
+        entryPointIds.value = []
     }
 
-    return { nodes, edges, setGraph, addToGraph, reset }
+    return { nodes, edges, entryPointIds, setGraph, addToGraph, reset }
 })

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -4,6 +4,10 @@ export const useUiStore = defineStore('ui', () => {
     // 'type' colors nodes by Tool/Database/Publication; 'topic' colors them by
     // their Louvain community (shared with Network.vue and Legend.vue).
     const colorMode = ref('type')
+    // Independent per colorMode: hiding a type in 'type' mode doesn't affect what's
+    // hidden when switching to 'topic' mode, and vice versa.
+    const hiddenTypes = ref([])
+    const hiddenCommunities = ref([])
 
     function toggleSidebar () {
         sidebarOpen.value = !sidebarOpen.value
@@ -21,5 +25,35 @@ export const useUiStore = defineStore('ui', () => {
         colorMode.value = mode
     }
 
-    return { sidebarOpen, toggleSidebar, setSidebarOpen, legendOpen, toggleLegend, colorMode, setColorMode }
+    function toggleHiddenType (type) {
+        hiddenTypes.value = hiddenTypes.value.includes(type)
+            ? hiddenTypes.value.filter((t) => t !== type)
+            : [...hiddenTypes.value, type]
+    }
+
+    function toggleHiddenCommunity (id) {
+        hiddenCommunities.value = hiddenCommunities.value.includes(id)
+            ? hiddenCommunities.value.filter((c) => c !== id)
+            : [...hiddenCommunities.value, id]
+    }
+
+    function resetLayers () {
+        hiddenTypes.value = []
+        hiddenCommunities.value = []
+    }
+
+    return {
+        sidebarOpen,
+        toggleSidebar,
+        setSidebarOpen,
+        legendOpen,
+        toggleLegend,
+        colorMode,
+        setColorMode,
+        hiddenTypes,
+        hiddenCommunities,
+        toggleHiddenType,
+        toggleHiddenCommunity,
+        resetLayers
+    }
 })

--- a/FRONTEND-nuxt/app/utils/graphVisibility.js
+++ b/FRONTEND-nuxt/app/utils/graphVisibility.js
@@ -1,0 +1,21 @@
+// A node is hidden if its type is in hiddenTypes OR its community is in
+// hiddenCommunities — both rule sets apply at once regardless of which legend tab
+// (By type / By topic) you're currently looking at, so toggling a layer in one view
+// stays applied when you switch to the other. Entry-point nodes (the tool/database
+// actually searched for, not just a neighbour) are always exempt — they should never
+// disappear behind a layer filter.
+export function isNodeHidden (node, { hiddenTypes, hiddenCommunities, entryPointIds = [] }) {
+    if (entryPointIds.includes(node.id)) return false
+    return hiddenTypes.includes(node.type) || hiddenCommunities.includes(node.properties?.community)
+}
+
+// Drops hidden nodes and any edge touching one — used for the JSON export so the file
+// matches what's actually on screen. The PNG export gets this for free (Cytoscape
+// simply doesn't draw display:none elements), but the JSON is built straight from
+// graphStore, which has no notion of "currently hidden".
+export function filterVisibleGraph (nodes, edges, visibility) {
+    const visibleNodes = nodes.filter((node) => !isNodeHidden(node, visibility))
+    const visibleIds = new Set(visibleNodes.map((node) => node.id))
+    const visibleEdges = edges.filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target))
+    return { nodes: visibleNodes, edges: visibleEdges }
+}

--- a/FRONTEND-nuxt/app/utils/typeColors.js
+++ b/FRONTEND-nuxt/app/utils/typeColors.js
@@ -1,0 +1,17 @@
+// Node fill/border color by type ('Tool' | 'Database' | 'Publication') — the same
+// colors Network.vue paints on the canvas in 'type' mode, pulled from the same CSS
+// custom properties so a change to main.scss can't silently desync the two.
+export function getTypeColor (type) {
+    const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+    const bg = {
+        Tool: cssVar('--insolito-node-primary'),
+        Database: cssVar('--insolito-node-tertiary'),
+        Publication: cssVar('--insolito-node-secondary')
+    }
+    const border = {
+        Tool: cssVar('--insolito-primary'),
+        Database: cssVar('--insolito-node-tertiary-dark'),
+        Publication: cssVar('--insolito-secondary-hover')
+    }
+    return { bg: bg[type] || '#999999', border: border[type] || '#666666' }
+}


### PR DESCRIPTION
## Summary

Add layer toggling to the Legend

## Changes

**New files:**
- `FRONTEND-nuxt/app/utils/graphVisibility.js` — shared graph visibility helpers (`isNodeHidden()` and `filterVisibleGraph()`), hiding nodes by type or community while always keeping entry-point nodes visible.
- `FRONTEND-nuxt/app/utils/typeColors.js` — extracts `getTypeColor()` from `Network.vue` into a shared utility.

**Modified files:**
- `FRONTEND-nuxt/app/stores/ui.js` — adds `hiddenTypes` and `hiddenCommunities` state, plus `toggleHiddenType()`, `toggleHiddenCommunity()`, and `resetLayers()`.
- `FRONTEND-nuxt/app/stores/graph.js` — adds `entryPointIds` (persisting across searches like nodes and edges) and clears it on `reset()`.
- `FRONTEND-nuxt/app/composables/useNeo4jSearch.js` — identifies the searched Tool/Database node and returns its `entryPointId`.
- `FRONTEND-nuxt/app/components/graph/Network.vue` — adds `hiddenTypes`, `hiddenCommunities`, and `entryPointIds` props.
- `FRONTEND-nuxt/app/components/graph/Screen.vue` — passes the new props to `GraphNetwork`.
- `FRONTEND-nuxt/app/components/graph/Legend.vue` — makes every type and community entry clickable to toggle its layer.
- `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — passes the resolved `entryPointId` to `graphStore.addToGraph()` and filters JSON exports to only include currently visible nodes and edges.

## Issues

Closes #165