### PR TITLE
[REFACTOR] Loading indicator

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -19,7 +19,25 @@
     <main class="graph-main" :class="uiStore.sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
       <GraphLegend v-if="graphStore.nodes.length" />
       <GraphNodeInfoPanel v-if="selectedNode" :node="selectedNode" @close="selectedNode = null" />
-      <p v-if="graphStore.nodes.length === 0" class="graph-empty-state">
+      <div v-if="uiStore.rebuilding" class="graph-loading-overlay">
+        <svg viewBox="0 0 80 80" class="graph-loading-svg" aria-hidden="true">
+          <g class="graph-loading-edges">
+            <line x1="40" y1="40" x2="12" y2="24" />
+            <line x1="40" y1="40" x2="66" y2="18" />
+            <line x1="40" y1="40" x2="20" y2="64" />
+            <line x1="40" y1="40" x2="62" y2="60" />
+          </g>
+          <g class="graph-loading-nodes">
+            <circle cx="40" cy="40" r="7" class="loading-node loading-node-hub" />
+            <circle cx="12" cy="24" r="5" class="loading-node" style="animation-delay:0.15s" />
+            <circle cx="66" cy="18" r="5" class="loading-node" style="animation-delay:0.3s" />
+            <circle cx="20" cy="64" r="5" class="loading-node" style="animation-delay:0.45s" />
+            <circle cx="62" cy="60" r="5" class="loading-node" style="animation-delay:0.6s" />
+          </g>
+        </svg>
+        <span class="graph-loading-text">Searching…</span>
+      </div>
+      <p v-if="graphStore.nodes.length === 0 && !uiStore.rebuilding" class="graph-empty-state">
         {{ graphStore.searchTerms.length
           ? 'No results found for the current search and filters.'
           : 'Search for a tool, database, or topic in the sidebar to get started.' }}
@@ -160,5 +178,57 @@ onMounted(() => {
     font-size: 1rem;
     text-align: center;
     pointer-events: none;
+}
+
+.graph-loading-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 6;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    background: rgba(255, 255, 255, 0.90);
+    pointer-events: none;
+}
+
+.graph-loading-text {
+    color: var(--insolito-text);
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.graph-loading-svg {
+    width: 72px;
+    height: 72px;
+}
+
+.graph-loading-edges line {
+    stroke: var(--insolito-edge);
+    stroke-width: 1.5;
+}
+
+.loading-node {
+    fill: var(--insolito-primary);
+    transform-origin: center;
+    transform-box: fill-box;
+    animation: graph-loading-node-pulse 1.2s ease-in-out infinite;
+}
+
+.loading-node-hub {
+    fill: var(--insolito-primary-dark);
+    animation: none;
+}
+
+@keyframes graph-loading-node-pulse {
+    0%, 100% {
+        transform: scale(1);
+        opacity: 0.6;
+    }
+    50% {
+        transform: scale(1.4);
+        opacity: 1;
+    }
 }
 </style>

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -14,7 +14,7 @@
           type="text"
           placeholder="blast, 1000Genomes, MEGA..."
           class="graph-sidebar-search-input"
-          :disabled="rebuilding"
+          :disabled="uiStore.rebuilding"
           autocomplete="off"
           @focus="showSuggestions = true"
           @blur="onInputBlur"
@@ -40,11 +40,11 @@
       <BButton
         class="graph-sidebar-search-btn"
         :class="{ 'graph-sidebar-search-btn-stale': filtersStale }"
-        :disabled="rebuilding || (!searchTerm.trim() && graphStore.searchTerms.length === 0)"
+        :disabled="uiStore.rebuilding || (!searchTerm.trim() && graphStore.searchTerms.length === 0)"
         :title="filtersStale ? 'Filters changed — click Search to update the graph' : undefined"
         @click="onSearchClick"
       >
-        {{ rebuilding ? 'Searching…' : 'Search' }}<span v-if="filtersStale && !rebuilding" aria-hidden="true"> ⚠</span>
+        {{ uiStore.rebuilding ? 'Searching…' : 'Search' }}<span v-if="filtersStale && !uiStore.rebuilding" aria-hidden="true"> ⚠</span>
       </BButton>
       <div v-if="searchError || connectionError || searchNotice || emptyResultTerms.length" class="graph-toast-stack">
         <p v-if="searchError" class="graph-toast graph-toast-warning">{{ searchError }}</p>
@@ -100,7 +100,7 @@
               type="button"
               class="graph-sidebar-search-term-remove"
               :aria-label="`Remove ${term.name}`"
-              :disabled="rebuilding"
+              :disabled="uiStore.rebuilding"
               @click="onRemoveSearchTerm(term)"
             >
               ×
@@ -152,7 +152,6 @@ const emptyResultTerms = ref([])
 
 const showSuggestions = ref(false)
 const highlightedIndex = ref(-1)
-const rebuilding = ref(false)
 const suggestions = computed(() => suggestSearchTerms(searchTerm.value))
 
 // Snapshot of the year/occurrence values that produced the graph currently on
@@ -242,7 +241,7 @@ async function rebuildGraph () {
         connectionError.value = ''
         return
     }
-    rebuilding.value = true
+    uiStore.setRebuilding(true)
     connectionError.value = ''
     emptyResultTerms.value = []
     try {
@@ -264,7 +263,7 @@ async function rebuildGraph () {
     } catch (e) {
         connectionError.value = classifySearchError(e)
     } finally {
-        rebuilding.value = false
+        uiStore.setRebuilding(false)
     }
 }
 

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -8,6 +8,13 @@ export const useUiStore = defineStore('ui', () => {
     // hidden when switching to 'topic' mode, and vice versa.
     const hiddenTypes = ref([])
     const hiddenCommunities = ref([])
+    // True while Sidebar's rebuildGraph() has an in-flight request — read by
+    // Screen.vue too, to show a loading indicator over the canvas.
+    const rebuilding = ref(false)
+
+    function setRebuilding (value) {
+        rebuilding.value = value
+    }
 
     function toggleSidebar () {
         sidebarOpen.value = !sidebarOpen.value
@@ -54,6 +61,8 @@ export const useUiStore = defineStore('ui', () => {
         hiddenCommunities,
         toggleHiddenType,
         toggleHiddenCommunity,
-        resetLayers
+        resetLayers,
+        rebuilding,
+        setRebuilding
     }
 })


### PR DESCRIPTION
## Summary

Add a loading indicator over the graph canvas during searches.

## Changes

**Modified files:**

* `FRONTEND-nuxt/app/stores/ui.js` — moves `rebuilding` from Sidebar's local state into the UI store with `setRebuilding()`, allowing both the Search button and canvas overlay to access it.

* `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — updates all `rebuilding` reads and writes to use `uiStore`.

* `FRONTEND-nuxt/app/components/graph/Screen.vue` — adds a full-canvas loading overlay based on `uiStore.rebuilding`.

## Issues

Closes #175
