### PR TITLE
[REFACTOR] Logo links back to landing page

### DIFF
--- a/FRONTEND-nuxt/app/app.vue
+++ b/FRONTEND-nuxt/app/app.vue
@@ -2,7 +2,7 @@
   <BApp>
     <NuxtRouteAnnouncer />
     <div v-if="showGraph">
-      <GraphScreen />
+      <GraphScreen @go-home="showGraph = false" />
     </div>
     <div v-else class="enter-webpage">
       <LandingHero @explore="showGraph = true" @about="showAbout = true" />

--- a/FRONTEND-nuxt/app/components/graph/Legend.vue
+++ b/FRONTEND-nuxt/app/components/graph/Legend.vue
@@ -8,6 +8,7 @@
           class="legend-mode-btn"
           :class="{ 'legend-mode-btn-active': uiStore.colorMode === 'type' }"
           :aria-selected="uiStore.colorMode === 'type'"
+          :disabled="uiStore.busy"
           @click="uiStore.setColorMode('type')"
         >
           By type
@@ -18,6 +19,7 @@
           class="legend-mode-btn"
           :class="{ 'legend-mode-btn-active': uiStore.colorMode === 'topic' }"
           :aria-selected="uiStore.colorMode === 'topic'"
+          :disabled="uiStore.busy"
           @click="uiStore.setColorMode('topic')"
         >
           By topic
@@ -27,6 +29,7 @@
         class="legend-collapse-btn"
         :aria-expanded="uiStore.legendOpen"
         aria-label="Toggle legend"
+        :disabled="uiStore.busy"
         @click="uiStore.toggleLegend()"
       >
         <svg
@@ -46,6 +49,7 @@
           class="legend-item"
           :class="{ 'legend-item-hidden': uiStore.hiddenTypes.includes(type.value) }"
           :aria-pressed="!uiStore.hiddenTypes.includes(type.value)"
+          :disabled="uiStore.busy"
           @click="uiStore.toggleHiddenType(type.value)"
         >
           <span class="legend-dot" :class="`legend-dot-${type.value.toLowerCase()}`" />
@@ -61,6 +65,7 @@
           class="legend-item"
           :class="{ 'legend-item-hidden': uiStore.hiddenCommunities.includes(entry.id) }"
           :aria-pressed="!uiStore.hiddenCommunities.includes(entry.id)"
+          :disabled="uiStore.busy"
           @click="uiStore.toggleHiddenCommunity(entry.id)"
         >
           <span class="legend-dot" :style="{ background: entry.bg, borderColor: entry.border }" />
@@ -219,6 +224,13 @@ const topicEntries = computed(() => {
 
 .legend-item-hidden {
     opacity: 0.4;
+}
+
+.legend-mode-btn:disabled,
+.legend-collapse-btn:disabled,
+.legend-item:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
 }
 
 .legend-empty {

--- a/FRONTEND-nuxt/app/components/graph/Network.vue
+++ b/FRONTEND-nuxt/app/components/graph/Network.vue
@@ -22,7 +22,7 @@ const props = defineProps({
     entryPointIds: { type: Array, default: () => [] }
 })
 
-const emit = defineEmits(['node-click', 'background-click'])
+const emit = defineEmits(['node-click', 'background-click', 'ready'])
 
 const containerEl = ref(null)
 let cy = null
@@ -68,7 +68,12 @@ const layoutOptions = {
 }
 
 function runLayout () {
-    cy.layout(layoutOptions).run()
+    // .one() registered on the layout object itself (not cy), so it only fires for
+    // this run — Screen.vue relies on "ready" to know the graph is actually settled,
+    // not just that new data arrived, before turning off the loading overlay.
+    const layout = cy.layout(layoutOptions)
+    layout.one('layoutstop', () => emit('ready'))
+    layout.run()
 }
 
 // bg is passed explicitly because cy.png() renders on an offscreen canvas
@@ -101,83 +106,103 @@ function applyVisibility () {
 }
 
 onMounted(() => {
-    for (const type of ['Tool', 'Database', 'Publication']) {
-        const color = getTypeColor(type)
-        nodeColor[type] = color.bg
-        nodeBorderColor[type] = color.border
-    }
-
-    clusterColors = buildClusterColorMap(props.nodes)
-
-    cy = cytoscape({
-        container: containerEl.value,
-        elements: toElements(),
-        style: [
-            {
-                selector: 'node',
-                style: {
-                    'background-color': (el) => {
-                        if (props.colorMode === 'topic') {
-                            return clusterColors[el.data('properties')?.community]?.bg || '#999999'
-                        }
-                        return nodeColor[el.data('type')] || '#999999'
-                    },
-                    'border-color': (el) => {
-                        if (props.colorMode === 'topic') {
-                            return clusterColors[el.data('properties')?.community]?.border || '#666666'
-                        }
-                        return nodeBorderColor[el.data('type')] || '#666666'
-                    },
-                    // Entry points stand out via a slightly bigger size + a slightly
-                    // wider single border + bolder/bigger label — same fill color
-                    // (type/topic) as every other node.
-                    'border-width': (el) => (isEntryPoint(el) ? 4 : 2),
-                    width: (el) => (isEntryPoint(el) ? 40 : 34),
-                    height: (el) => (isEntryPoint(el) ? 40 : 34),
-                    label: 'data(label)',
-                    'font-size': (el) => (isEntryPoint(el) ? 14 : 12),
-                    'font-weight': (el) => (isEntryPoint(el) ? 'bold' : 'normal'),
-                    color: cssVar('--insolito-text'),
-                    'text-valign': 'bottom',
-                    'text-margin-y': 6
-                }
-            },
-            {
-                selector: 'edge',
-                style: {
-                    width: 'mapData(weight, 1, 10, 1, 6)',
-                    'line-color': cssVar('--insolito-edge'),
-                    'curve-style': 'bezier'
-                }
-            },
-            {
-                selector: '.layer-hidden',
-                style: { display: 'none' }
-            }
-        ],
-        layout: layoutOptions
-    })
-
-    cy.on('tap', 'node', (event) => {
-        emit('node-click', event.target.data())
-    })
-
-    cy.on('tap', (event) => {
-        if (event.target === cy) {
-            emit('background-click')
+    // The cytoscape constructor + its initial fcose layout run synchronously and can
+    // block the main thread for a noticeable moment on a large restored graph — with
+    // no network wait to cover it (unlike a fresh search), that would freeze the UI
+    // between clicking "Explore" and the screen appearing. A single requestAnimationFrame
+    // isn't enough — it still fires before the browser paints the current frame. setTimeout
+    // pushes the work to a new macrotask, after the browser has had a chance to paint the
+    // mounted screen (with its loading overlay) first.
+    setTimeout(() => {
+        for (const type of ['Tool', 'Database', 'Publication']) {
+            const color = getTypeColor(type)
+            nodeColor[type] = color.bg
+            nodeBorderColor[type] = color.border
         }
-    })
 
-    applyVisibility()
+        clusterColors = buildClusterColorMap(props.nodes)
+
+        cy = cytoscape({
+            container: containerEl.value,
+            elements: toElements(),
+            ready: function () {
+                // Fires once the initial layout (constructor's `layout` option) settles —
+                // used by Screen.vue to know when a restored graph has finished laying out.
+                this.one('layoutstop', () => emit('ready'))
+            },
+            style: [
+                {
+                    selector: 'node',
+                    style: {
+                        'background-color': (el) => {
+                            if (props.colorMode === 'topic') {
+                                return clusterColors[el.data('properties')?.community]?.bg || '#999999'
+                            }
+                            return nodeColor[el.data('type')] || '#999999'
+                        },
+                        'border-color': (el) => {
+                            if (props.colorMode === 'topic') {
+                                return clusterColors[el.data('properties')?.community]?.border || '#666666'
+                            }
+                            return nodeBorderColor[el.data('type')] || '#666666'
+                        },
+                        // Entry points stand out via a slightly bigger size + a slightly
+                        // wider single border + bolder/bigger label — same fill color
+                        // (type/topic) as every other node.
+                        'border-width': (el) => (isEntryPoint(el) ? 4 : 2),
+                        width: (el) => (isEntryPoint(el) ? 40 : 34),
+                        height: (el) => (isEntryPoint(el) ? 40 : 34),
+                        label: 'data(label)',
+                        'font-size': (el) => (isEntryPoint(el) ? 14 : 12),
+                        'font-weight': (el) => (isEntryPoint(el) ? 'bold' : 'normal'),
+                        color: cssVar('--insolito-text'),
+                        'text-valign': 'bottom',
+                        'text-margin-y': 6
+                    }
+                },
+                {
+                    selector: 'edge',
+                    style: {
+                        width: 'mapData(weight, 1, 10, 1, 6)',
+                        'line-color': cssVar('--insolito-edge'),
+                        'curve-style': 'bezier'
+                    }
+                },
+                {
+                    selector: '.layer-hidden',
+                    style: { display: 'none' }
+                }
+            ],
+            layout: layoutOptions
+        })
+
+        cy.on('tap', 'node', (event) => {
+            emit('node-click', event.target.data())
+        })
+
+        cy.on('tap', (event) => {
+            if (event.target === cy) {
+                emit('background-click')
+            }
+        })
+
+        applyVisibility()
+    }, 0)
 })
 
 watch([() => props.nodes, () => props.edges], () => {
     if (!cy) return
-    clusterColors = buildClusterColorMap(props.nodes)
-    cy.elements().remove()
-    cy.add(toElements())
-    runLayout()
-    applyVisibility()
+    // Deferred so the browser gets to paint the "Building graph…" phase text (set by
+    // Sidebar.vue right before this data change) before the synchronous, blocking
+    // cy.add() + runLayout() computation runs — without this gap the phase flips and
+    // the layout finishes within the same tick, so the text never actually renders.
+    setTimeout(() => {
+        clusterColors = buildClusterColorMap(props.nodes)
+        cy.elements().remove()
+        cy.add(toElements())
+        runLayout()
+        applyVisibility()
+    }, 0)
 }, { deep: true })
 
 // Style functions read props.colorMode directly, but Cytoscape only re-evaluates them

--- a/FRONTEND-nuxt/app/components/graph/RangeSlider.vue
+++ b/FRONTEND-nuxt/app/components/graph/RangeSlider.vue
@@ -1,5 +1,10 @@
 <template>
-  <div ref="trackRef" class="range-slider" @pointerdown="onTrackPointerDown">
+  <div
+    ref="trackRef"
+    class="range-slider"
+    :class="{ 'range-slider-disabled': disabled }"
+    @pointerdown="onTrackPointerDown"
+  >
     <div class="range-slider-fill" :style="fillStyle" />
     <button
       v-for="(percent, i) in thumbPercents"
@@ -12,7 +17,8 @@
       :aria-valuemin="min"
       :aria-valuemax="max"
       :aria-valuenow="values[i]"
-      tabindex="0"
+      :aria-disabled="disabled"
+      :tabindex="disabled ? -1 : 0"
       @pointerdown.stop="startDrag(i, $event)"
       @keydown="onKeydown(i, $event)"
     />
@@ -25,6 +31,7 @@ const props = defineProps({
     max: { type: Number, required: true },
     modelValue: { type: [Number, Array], required: true },
     step: { type: Number, default: 1 },
+    disabled: { type: Boolean, default: false },
     // Optional non-linear mapping (e.g. log scale). Both default to linear over [min, max].
     toPercent: { type: Function, default: null },
     fromPercent: { type: Function, default: null }
@@ -83,6 +90,7 @@ function applyToIndex (index, value) {
 let dragIndex = null
 
 function startDrag (index, event) {
+    if (props.disabled) return
     dragIndex = index
     event.target.setPointerCapture(event.pointerId)
     window.addEventListener('pointermove', onDrag)
@@ -104,6 +112,7 @@ function stopDrag () {
 }
 
 function onTrackPointerDown (event) {
+    if (props.disabled) return
     const percent = percentFromEvent(event)
     const distances = values.value.map((v) => Math.abs(valueToPercent(v) - percent))
     const index = distances.length > 1 && distances[1] < distances[0] ? 1 : 0
@@ -114,6 +123,7 @@ function onTrackPointerDown (event) {
 }
 
 function onKeydown (index, event) {
+    if (props.disabled) return
     let delta = 0
     if (event.key === 'ArrowRight' || event.key === 'ArrowUp') delta = props.step
     else if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') delta = -props.step
@@ -181,5 +191,14 @@ function commitValue (index, rawValue) {
 .range-slider-thumb:focus-visible {
     outline: 2px solid var(--insolito-secondary);
     outline-offset: 2px;
+}
+
+.range-slider-disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.range-slider-disabled .range-slider-thumb {
+    cursor: not-allowed;
 }
 </style>

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="graph-screen">
-    <GraphSidebar :open="uiStore.sidebarOpen" @reset="onReset" @export-png="onExportPng" />
+    <GraphSidebar :open="uiStore.sidebarOpen" @reset="onReset" @export-png="onExportPng" @go-home="$emit('go-home')" />
 
     <div v-if="uiStore.sidebarOpen" class="sidebar-backdrop" @click="uiStore.setSidebarOpen(false)" />
 
@@ -19,7 +19,7 @@
     <main class="graph-main" :class="uiStore.sidebarOpen ? 'graph-main-with-sidebar' : 'graph-main-without-sidebar'">
       <GraphLegend v-if="graphStore.nodes.length" />
       <GraphNodeInfoPanel v-if="selectedNode" :node="selectedNode" @close="selectedNode = null" />
-      <div v-if="uiStore.rebuilding" class="graph-loading-overlay">
+      <div v-if="uiStore.busy" class="graph-loading-overlay">
         <svg viewBox="0 0 80 80" class="graph-loading-svg" aria-hidden="true">
           <g class="graph-loading-edges">
             <line x1="40" y1="40" x2="12" y2="24" />
@@ -35,7 +35,7 @@
             <circle cx="62" cy="60" r="5" class="loading-node" style="animation-delay:0.6s" />
           </g>
         </svg>
-        <span class="graph-loading-text">Searching…</span>
+        <span class="graph-loading-text">{{ loadingText }}</span>
       </div>
       <p v-if="graphStore.nodes.length === 0 && !uiStore.rebuilding" class="graph-empty-state">
         {{ graphStore.searchTerms.length
@@ -53,17 +53,29 @@
         class="graph-canvas"
         @node-click="selectedNode = $event"
         @background-click="selectedNode = null"
+        @ready="onNetworkReady"
       />
     </main>
   </div>
 </template>
 
 <script setup>
+defineEmits(['go-home'])
+
 const graphStore = useGraphStore()
 const uiStore = useUiStore()
 
 const selectedNode = ref(null)
 const networkRef = ref(null)
+// Only true right when this screen mounts with an already-populated graph (i.e.
+// returning from landing via "Explore", not a fresh search) — cleared once
+// GraphNetwork's initial layout settles. False when there's nothing to restore.
+uiStore.setRestoringGraph(graphStore.nodes.length > 0)
+
+const loadingText = computed(() => {
+    if (!uiStore.rebuilding) return 'Restoring graph…'
+    return uiStore.rebuildPhase === 'building' ? 'Building graph…' : 'Searching…'
+})
 
 function onReset () {
     graphStore.reset()
@@ -74,6 +86,15 @@ function onReset () {
 function onExportPng () {
     const dataUri = networkRef.value?.exportPng()
     if (dataUri) downloadDataUri(dataUri, 'InSoLiTo-network.png')
+}
+
+// Fires whenever GraphNetwork's layout settles — both the initial mount (restoring
+// a graph from landing) and every subsequent relayout triggered by a search. Rebuilding
+// is only cleared here, not right after the fetch, so the sidebar (search button,
+// sliders) stays disabled for the full duration the main thread is actually busy.
+function onNetworkReady () {
+    uiStore.setRestoringGraph(false)
+    uiStore.setRebuilding(false)
 }
 
 onMounted(() => {

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -1,8 +1,10 @@
 <template>
   <aside class="graph-sidebar" :class="open ? 'graph-sidebar-open' : 'graph-sidebar-closed'">
-    <img src="~/assets/images/logo_InSoLiTo.png" alt="InSoLiTo Logo" class="graph-sidebar-logo">
+    <button type="button" class="graph-sidebar-logo-btn" aria-label="Back to home" @click="$emit('go-home')">
+      <img src="~/assets/images/logo_InSoLiTo.png" alt="InSoLiTo Logo" class="graph-sidebar-logo">
+    </button>
 
-    <BButton class="graph-sidebar-reset" @click="onReset">
+    <BButton class="graph-sidebar-reset" :disabled="uiStore.busy" @click="onReset">
       Reset
     </BButton>
 
@@ -14,7 +16,7 @@
           type="text"
           placeholder="blast, 1000Genomes, MEGA..."
           class="graph-sidebar-search-input"
-          :disabled="uiStore.rebuilding"
+          :disabled="uiStore.busy"
           autocomplete="off"
           @focus="showSuggestions = true"
           @blur="onInputBlur"
@@ -40,7 +42,7 @@
       <BButton
         class="graph-sidebar-search-btn"
         :class="{ 'graph-sidebar-search-btn-stale': filtersStale }"
-        :disabled="uiStore.rebuilding || (!searchTerm.trim() && graphStore.searchTerms.length === 0)"
+        :disabled="uiStore.busy || (!searchTerm.trim() && graphStore.searchTerms.length === 0)"
         :title="filtersStale ? 'Filters changed — click Search to update the graph' : undefined"
         @click="onSearchClick"
       >
@@ -63,6 +65,7 @@
         v-model="yearRange"
         :min="yearDomainMin"
         :max="yearDomainMax"
+        :disabled="uiStore.busy"
         @change="onYearChange"
       />
       <p class="graph-sidebar-filter-value">{{ yearRange[0] }} – {{ yearRange[1] }}</p>
@@ -77,6 +80,7 @@
         :max="occurrenceDomainMax"
         :to-percent="occurrenceToPercent"
         :from-percent="occurrencePercentToValue"
+        :disabled="uiStore.busy"
         @change="onOccurrenceChange"
       />
       <p class="graph-sidebar-filter-value">{{ occurrenceValue }}</p>
@@ -100,7 +104,7 @@
               type="button"
               class="graph-sidebar-search-term-remove"
               :aria-label="`Remove ${term.name}`"
-              :disabled="uiStore.rebuilding"
+              :disabled="uiStore.busy"
               @click="onRemoveSearchTerm(term)"
             >
               ×
@@ -113,10 +117,10 @@
     <section v-if="graphStore.nodes.length" class="graph-sidebar-export">
       <h3 class="graph-sidebar-filter-title">Export</h3>
       <div class="graph-sidebar-export-buttons">
-        <BButton variant="outline-secondary" size="sm" @click="$emit('export-png')">
+        <BButton variant="outline-secondary" size="sm" :disabled="uiStore.busy" @click="$emit('export-png')">
           PNG
         </BButton>
-        <BButton variant="outline-secondary" size="sm" @click="onExportJson">
+        <BButton variant="outline-secondary" size="sm" :disabled="uiStore.busy" @click="onExportJson">
           JSON
         </BButton>
       </div>
@@ -131,7 +135,7 @@ import OccurData from '../../../../DB/RelationshipSliderData.json'
 defineProps({
     open: { type: Boolean, default: true }
 })
-const emit = defineEmits(['reset', 'export-png'])
+const emit = defineEmits(['reset', 'export-png', 'go-home'])
 
 const filterStore = useFilterStore()
 const graphStore = useGraphStore()
@@ -242,6 +246,7 @@ async function rebuildGraph () {
         return
     }
     uiStore.setRebuilding(true)
+    uiStore.setRebuildPhase('searching')
     connectionError.value = ''
     emptyResultTerms.value = []
     try {
@@ -254,15 +259,18 @@ async function rebuildGraph () {
             yearMin: filterStore.yearMin,
             yearMax: filterStore.yearMax
         })))
+        uiStore.setRebuildPhase('building')
         graphStore.clearResults()
         results.forEach(({ nodes, edges, entryPointId }) => graphStore.addToGraph(nodes, edges, entryPointId))
         emptyResultTerms.value = graphStore.searchTerms
             .filter((_, index) => results[index].nodes.length === 0)
             .map((term) => term.name)
         lastAppliedFilters.value = { yearMin: yearRange.value[0], yearMax: yearRange.value[1], occurrenceMin: occurrenceValue.value }
+        // rebuilding stays true here on purpose — Screen.vue clears it once GraphNetwork's
+        // relayout for this new data actually finishes (see onNetworkReady), not right after
+        // the fetch, so the sidebar doesn't re-enable while the layout is still computing.
     } catch (e) {
         connectionError.value = classifySearchError(e)
-    } finally {
         uiStore.setRebuilding(false)
     }
 }
@@ -368,6 +376,20 @@ function onReset () {
 
 .graph-sidebar-closed {
     transform: translateX(-100%);
+}
+
+.graph-sidebar-logo-btn {
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    line-height: 0;
+    opacity: 1;
+    transition: opacity 0.15s ease;
+}
+
+.graph-sidebar-logo-btn:hover {
+    opacity: 0.8;
 }
 
 .graph-sidebar-logo {

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -11,9 +11,29 @@ export const useUiStore = defineStore('ui', () => {
     // True while Sidebar's rebuildGraph() has an in-flight request — read by
     // Screen.vue too, to show a loading indicator over the canvas.
     const rebuilding = ref(false)
+    // Which part of rebuildGraph() is running, so Screen.vue's overlay text can be
+    // accurate: 'searching' during the Neo4j request, 'building' once results are
+    // in and Cytoscape is computing the layout. Only meaningful while rebuilding is true.
+    const rebuildPhase = ref('searching')
+    // True only right after Screen.vue mounts with an already-populated graph (i.e.
+    // returning from the landing page via "Explore") — cleared once GraphNetwork's
+    // initial layout settles. Combined with `rebuilding` below into `busy`, since the
+    // sidebar/legend should be just as unusable during a restore as during a search.
+    const restoringGraph = ref(false)
+    // Single flag every sidebar/legend control disables against — true while either
+    // a search or a graph restore is in flight.
+    const busy = computed(() => rebuilding.value || restoringGraph.value)
 
     function setRebuilding (value) {
         rebuilding.value = value
+    }
+
+    function setRebuildPhase (phase) {
+        rebuildPhase.value = phase
+    }
+
+    function setRestoringGraph (value) {
+        restoringGraph.value = value
     }
 
     function toggleSidebar () {
@@ -63,6 +83,11 @@ export const useUiStore = defineStore('ui', () => {
         toggleHiddenCommunity,
         resetLayers,
         rebuilding,
-        setRebuilding
+        setRebuilding,
+        rebuildPhase,
+        setRebuildPhase,
+        restoringGraph,
+        setRestoringGraph,
+        busy
     }
 })


### PR DESCRIPTION
## Summary

Logo links back to landing page, with loading state properly disabling the sidebar throughout.

## Changes

**Modified files:**

* `FRONTEND-nuxt/app/app.vue` — toggles `showGraph` back to false on `go-home`, keeping the stores untouched.

* `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — logo emits `go-home`; `rebuildPhase` tracks fetch vs. relayout; `setRebuilding(false)` moves to the error path only. Reset, sliders, Search, Active searches, and Export are gated by `uiStore.busy`.

* `FRONTEND-nuxt/app/components/graph/Screen.vue` — re-emits `go-home`; seeds `restoringGraph` on mount if a graph exists; `onNetworkReady()` clears both `restoringGraph` and `rebuilding`; loading overlay text is now phase-aware.

* `FRONTEND-nuxt/app/components/graph/Network.vue` — defers initial Cytoscape initialization via `setTimeout` to avoid blocking the first paint; emits `ready` on every `layoutstop`, not just the initial one.

* `FRONTEND-nuxt/app/components/graph/Legend.vue` — disables mode tabs, collapse toggle, and legend entries while `uiStore.busy` is active.

* `FRONTEND-nuxt/app/components/graph/RangeSlider.vue` — adds a `disabled` prop that blocks interaction and dims the track.

* `FRONTEND-nuxt/app/stores/ui.js` — adds `restoringGraph`, `rebuildPhase`, and the combined `busy` computed, along with their setters.

## Issues

Closes #177
