### PR TITLE
[REFACTOR] Sidebar About and Help buttons

### DIFF
--- a/FRONTEND-nuxt/app/app.vue
+++ b/FRONTEND-nuxt/app/app.vue
@@ -5,15 +5,15 @@
       <GraphScreen @go-home="showGraph = false" />
     </div>
     <div v-else class="enter-webpage">
-      <LandingHero @explore="showGraph = true" @about="showAbout = true" />
+      <LandingHero @explore="showGraph = true" @about="uiStore.setAboutOpen(true)" />
       <LandingFooter />
     </div>
-    <LandingAboutModal v-model="showAbout" />
+    <LandingAboutModal :model-value="uiStore.aboutOpen" @update:model-value="uiStore.setAboutOpen($event)" />
   </BApp>
 </template>
 
 <script setup>
-const showAbout = ref(false)
+const uiStore = useUiStore()
 const showGraph = ref(false)
 </script>
 

--- a/FRONTEND-nuxt/app/components/graph/HowToUseModal.vue
+++ b/FRONTEND-nuxt/app/components/graph/HowToUseModal.vue
@@ -1,0 +1,83 @@
+<template>
+  <BModal
+    :model-value="modelValue"
+    title="How to use InSoLiTo"
+    size="lg"
+    ok-only
+    ok-title="Close"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <section class="how-to-section">
+      <h6>What you searched for</h6>
+      <p>
+        Searching a <strong>Tool</strong> or <strong>Database</strong> matches it exactly. Searching a
+        <strong>Topic</strong> is broader: it walks the EDAM ontology's subclass hierarchy and pulls in
+        every tool tagged with that topic <em>or</em> any of its more specific sub-topics, then draws
+        every co-citation edge among all of them at once.
+      </p>
+    </section>
+
+    <hr>
+    <section class="how-to-section">
+      <h6>What an edge means</h6>
+      <p>
+        An edge is a <strong>co-citation</strong>, not a citation and not shared usage in a pipeline: it
+        means some third publication cited both endpoints together in its own reference list. It does not
+        mean one endpoint cites the other, or that they were ever used together in practice. The thicker
+        the edge, the more publications co-cite that pair.
+      </p>
+    </section>
+
+    <hr>
+    <section class="how-to-section">
+      <h6>Node colors</h6>
+      <p>
+        In <strong>By type</strong> mode, color reflects what a node is: Tool, Database, or Publication.
+        In <strong>By topic</strong> mode, color reflects the node's community — a cluster detected purely
+        from how densely tools co-cite each other, with no input from EDAM. The topic label shown in the
+        legend is just the most common EDAM topic within that cluster, so a community can still mix
+        several topics.
+      </p>
+    </section>
+
+    <hr>
+    <section class="how-to-section">
+      <h6>The highlighted node</h6>
+      <p>
+        The node with the thicker border and bold label is the exact term you searched for — it always
+        stays visible and colored normally, even if you hide its type or cluster in the legend.
+      </p>
+    </section>
+
+    <hr>
+    <section class="how-to-section">
+      <h6>Filters</h6>
+      <p class="mb-0">
+        The publication year range and minimum co-citations sliders apply to every active search at once,
+        but only when you press <strong>Search</strong> — dragging a slider doesn't update the graph on
+        its own.
+      </p>
+    </section>
+  </BModal>
+</template>
+
+<script setup>
+defineProps({
+    modelValue: {
+        type: Boolean,
+        default: false
+    }
+})
+defineEmits(['update:modelValue'])
+</script>
+
+<style scoped>
+.how-to-section h6 {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--insolito-text-muted);
+    margin-bottom: 0.5rem;
+}
+</style>

--- a/FRONTEND-nuxt/app/components/graph/Screen.vue
+++ b/FRONTEND-nuxt/app/components/graph/Screen.vue
@@ -56,6 +56,8 @@
         @ready="onNetworkReady"
       />
     </main>
+
+    <GraphHowToUseModal :model-value="uiStore.howToOpen" @update:model-value="uiStore.setHowToOpen($event)" />
   </div>
 </template>
 

--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -8,6 +8,18 @@
       Reset
     </BButton>
 
+    <section class="graph-sidebar-meta">
+      <h3 class="graph-sidebar-filter-title">Help</h3>
+      <div class="graph-sidebar-meta-buttons">
+        <BButton variant="outline-secondary" size="sm" :disabled="uiStore.busy" @click="uiStore.setAboutOpen(true)">
+          About
+        </BButton>
+        <BButton variant="outline-secondary" size="sm" :disabled="uiStore.busy" @click="uiStore.setHowToOpen(true)">
+          How to use
+        </BButton>
+      </div>
+    </section>
+
     <section class="graph-sidebar-search">
       <h3 class="graph-sidebar-filter-title">Search</h3>
       <div class="graph-sidebar-search-input-wrap">
@@ -422,6 +434,23 @@ function onReset () {
 }
 
 .graph-sidebar-export-buttons .btn {
+    flex: 1;
+}
+
+.graph-sidebar-meta {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.graph-sidebar-meta-buttons {
+    width: 100%;
+    display: flex;
+    gap: 8px;
+}
+
+.graph-sidebar-meta-buttons .btn {
     flex: 1;
 }
 

--- a/FRONTEND-nuxt/app/stores/ui.js
+++ b/FRONTEND-nuxt/app/stores/ui.js
@@ -23,6 +23,12 @@ export const useUiStore = defineStore('ui', () => {
     // Single flag every sidebar/legend control disables against — true while either
     // a search or a graph restore is in flight.
     const busy = computed(() => rebuilding.value || restoringGraph.value)
+    // About modal is reachable from both the landing page (Hero's "About" button) and
+    // the graph screen (Sidebar) — lives in uiStore, not local component state, so
+    // both can open it. How-to-use is only ever opened from the graph screen, but kept
+    // alongside it for consistency (same button row, same on/off pattern).
+    const aboutOpen = ref(false)
+    const howToOpen = ref(false)
 
     function setRebuilding (value) {
         rebuilding.value = value
@@ -34,6 +40,14 @@ export const useUiStore = defineStore('ui', () => {
 
     function setRestoringGraph (value) {
         restoringGraph.value = value
+    }
+
+    function setAboutOpen (value) {
+        aboutOpen.value = value
+    }
+
+    function setHowToOpen (value) {
+        howToOpen.value = value
     }
 
     function toggleSidebar () {
@@ -88,6 +102,10 @@ export const useUiStore = defineStore('ui', () => {
         setRebuildPhase,
         restoringGraph,
         setRestoringGraph,
-        busy
+        busy,
+        aboutOpen,
+        setAboutOpen,
+        howToOpen,
+        setHowToOpen
     }
 })


### PR DESCRIPTION
## Summary

Add persistent About and How to use buttons to the sidebar.

## Changes

**New files:**

* `FRONTEND-nuxt/app/components/graph/HowToUseModal.vue` — adds a modal explaining what the graph represents, including Tool/Database/Topic searches, co-citation edges, node colors in By type and By topic modes, the highlighted entry-point node, and how filters apply.

**Modified files:**

* `FRONTEND-nuxt/app/stores/ui.js` — adds `aboutOpen` and `howToOpen` state with setters, moving the About modal state out of `app.vue` and making both modals accessible from the sidebar.

* `FRONTEND-nuxt/app/app.vue` — updates the About modal to read and write `uiStore.aboutOpen` instead of local state; Hero's About event now updates the store.

* `FRONTEND-nuxt/app/components/graph/Screen.vue` — mounts the new `HowToUseModal`, bound to `uiStore.howToOpen`.

* `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — adds a Help section with About and How to use buttons after Reset, disabled via `uiStore.busy` like the rest of the sidebar.

## Issues

Closes #178