### PR TITLE
[REFACTOR] Minimum co-citations

### DIFF
--- a/FRONTEND-nuxt/app/components/graph/Sidebar.vue
+++ b/FRONTEND-nuxt/app/components/graph/Sidebar.vue
@@ -335,7 +335,12 @@ const occurrenceLogMin = Math.log(occurrenceDomainMin)
 const occurrenceLogMax = Math.log(occurrenceDomainMax)
 const occurrenceToPercent = (value) => ((Math.log(value) - occurrenceLogMin) / (occurrenceLogMax - occurrenceLogMin)) * 100
 const occurrencePercentToValue = (percent) => Math.round(Math.exp(occurrenceLogMin + (percent / 100) * (occurrenceLogMax - occurrenceLogMin)))
-const occurrenceValue = ref(occurrenceDomainMin)
+// Defaults to 11, not the domain minimum (2) — most co-citation edges are weak
+// (times 2-4), so starting at the true minimum makes a hub search like BLAST fetch
+// and lay out a huge, mostly-noise neighbourhood. 11 matches the very first version
+// of the app's default, and is still adjustable down to occurrenceDomainMin via the slider.
+const OCCURRENCE_DEFAULT = 11
+const occurrenceValue = ref(OCCURRENCE_DEFAULT)
 
 function onOccurrenceChange () {
     filterStore.setFilters(yearRange.value[0], yearRange.value[1], occurrenceValue.value)
@@ -349,7 +354,7 @@ function onExportJson () {
 
 function onReset () {
     yearRange.value = [yearDomainMin, yearDomainMax]
-    occurrenceValue.value = occurrenceDomainMin
+    occurrenceValue.value = OCCURRENCE_DEFAULT
     searchTerm.value = ''
     searchError.value = ''
     connectionError.value = ''

--- a/FRONTEND-nuxt/app/stores/filter.js
+++ b/FRONTEND-nuxt/app/stores/filter.js
@@ -1,8 +1,16 @@
+// Must match Sidebar.vue's OCCURRENCE_DEFAULT — the slider's visual default is
+// meaningless if this store (what the query actually uses) doesn't start there too.
+const OCCURRENCE_DEFAULT = 11
+
 export const useFilterStore = defineStore('filter', () => {
-    // null means "no filter" (matches the METAOCCUR_ALL query variant, no year/occurrence condition)
+    // null means "no filter" (matches the METAOCCUR_ALL query variant, no year condition).
+    // occurrenceMin doesn't get the same "no filter" treatment: unlike year, most
+    // co-citation edges are weak (times 2-4), so an unfiltered first search on a hub
+    // tool fetches and lays out a huge, mostly-noise neighbourhood — it always starts
+    // at OCCURRENCE_DEFAULT instead.
     const yearMin = ref(null)
     const yearMax = ref(null)
-    const occurrenceMin = ref(null)
+    const occurrenceMin = ref(OCCURRENCE_DEFAULT)
 
     function setFilters (newYearMin, newYearMax, newOccurrenceMin) {
         yearMin.value = newYearMin
@@ -13,7 +21,7 @@ export const useFilterStore = defineStore('filter', () => {
     function reset () {
         yearMin.value = null
         yearMax.value = null
-        occurrenceMin.value = null
+        occurrenceMin.value = OCCURRENCE_DEFAULT
     }
 
     return { yearMin, yearMax, occurrenceMin, setFilters, reset }


### PR DESCRIPTION
## Summary

Raise default minimum co-citations to 11, fixing filterStore so it actually applies on first search.

## Changes

**Modified files:**

* `FRONTEND-nuxt/app/components/graph/Sidebar.vue` — sets `occurrenceValue` to the new `OCCURRENCE_DEFAULT` (11) instead of `occurrenceDomainMin` (2), both on initial load and in `onReset()`.

* `FRONTEND-nuxt/app/stores/filter.js` — sets `occurrenceMin` to `OCCURRENCE_DEFAULT` (11) instead of `null`. Previously, the slider's visual default was not propagated to the store until the user interacted with it, causing the first search of a session to use `cMin: 0` regardless of the displayed slider value.

## Issues

Closes #181
